### PR TITLE
Add pod metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ AppSignal for Kubernetes will start sending Kubernetes automatically.
 
 ## Metrics
 
-AppSignal for Kubernetes extracts metrics for all nodes running in a cluster every minute.
+AppSignal for Kubernetes extracts metrics for all nodes and pods running in a cluster every minute.
 
 It extracts the following metrics from the `/api/v1/nodes/<NODE>/proxy/stats/summary` endpoint:
+
+### Node metrics
 
 - node_cpu_usage_nano_cores
 - node_cpu_usage_core_nano_seconds
@@ -40,6 +42,14 @@ It extracts the following metrics from the `/api/v1/nodes/<NODE>/proxy/stats/sum
 - node_rlimit_curproc
 - node_swap_available_bytes
 - node_swap_usage_bytes
+
+### Pod metrics
+
+- pod_cpu_usage_nano_cores
+- pod_cpu_usage_core_nano_seconds
+- pod_memory_working_set_bytes
+- pod_swap_available_bytes
+- pod_swap_usage_bytes
 
 ## Automated Dashboard
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,13 +69,10 @@ async fn run() -> Result<(), Error> {
             .request::<serde_json::Value>(kube_request)
             .await?;
 
-        match kube_response["pods"].as_array() {
-            Some(pods) => {
-                for pod in pods {
-                    extract_pod_metrics(pod, pod["podRef"]["name"].as_str().unwrap(), &mut out);
-                }
+        if let Some(pods) = kube_response["pods"].as_array() {
+            for pod in pods {
+                extract_pod_metrics(pod, pod["podRef"]["name"].as_str().unwrap(), &mut out);
             }
-            None => (),
         };
 
         extract_node_metrics(kube_response, &name, &mut out);

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,7 @@ fn extract_node_metrics(results: Value, node_name: &str, out: &mut Vec<Appsignal
 #[cfg(test)]
 mod tests {
     use crate::extract_node_metrics;
+    use crate::extract_pod_metrics;
     use crate::AppsignalMetric;
     use crate::HashMap;
     use serde_json::json;
@@ -247,6 +248,45 @@ mod tests {
             AppsignalMetric::new(
                 "node_cpu_usage_nano_cores",
                 HashMap::from([("node".to_string(), "node".to_string())]),
+                &json!(232839439)
+            ),
+            out[0]
+        );
+    }
+
+    #[test]
+    fn extract_pod_metrics_with_empty_results() {
+        let mut out = Vec::new();
+        extract_pod_metrics(&json!([]), "pod", &mut out);
+        assert_eq!(
+            AppsignalMetric::new(
+                "pod_cpu_usage_nano_cores",
+                HashMap::from([("pod".to_string(), "pod".to_string())]),
+                &json!(0.0)
+            ),
+            out[0]
+        );
+    }
+
+    #[test]
+    fn extract_pod_metrics_with_results() {
+        let mut out = Vec::new();
+        extract_pod_metrics(
+            &json!({
+              "cpu": {
+               "time": "2024-03-29T12:21:36Z",
+               "usageNanoCores": 232839439,
+               "usageCoreNanoSeconds": 1118592000000 as u64
+              },
+            }),
+            "pod",
+            &mut out,
+        );
+
+        assert_eq!(
+            AppsignalMetric::new(
+                "pod_cpu_usage_nano_cores",
+                HashMap::from([("pod".to_string(), "pod".to_string())]),
                 &json!(232839439)
             ),
             out[0]

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,13 @@ async fn run() -> Result<(), Error> {
 
         if let Some(pods) = kube_response["pods"].as_array() {
             for pod in pods {
-                extract_pod_metrics(pod, pod["podRef"]["name"].as_str().unwrap(), &mut out);
+                extract_pod_metrics(
+                    pod,
+                    pod["podRef"]["name"]
+                        .as_str()
+                        .expect("Could not extract pod name"),
+                    &mut out,
+                );
             }
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,9 +69,14 @@ async fn run() -> Result<(), Error> {
             .request::<serde_json::Value>(kube_request)
             .await?;
 
-        for pod in kube_response["pods"].as_array().unwrap() {
-            extract_pod_metrics(pod, pod["podRef"]["name"].as_str().unwrap(), &mut out);
-        }
+        match kube_response["pods"].as_array() {
+            Some(pods) => {
+                for pod in pods {
+                    extract_pod_metrics(pod, pod["podRef"]["name"].as_str().unwrap(), &mut out);
+                }
+            }
+            None => (),
+        };
 
         extract_node_metrics(kube_response, &name, &mut out);
     }


### PR DESCRIPTION
This patch adds pod metrics next to the node metrics already reported. The pod-specific metrics will have a dashboard separate from the host metrics one on AppSignal.com.

Merging this will require an updated container to be pushed.