### PR TITLE
Implement volume metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "appsignal-kubernetes"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "http",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appsignal-kubernetes"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,14 @@ FROM rust:1.75.0-alpine3.19 AS build
 
 RUN apk add --no-cache clang libressl-dev
 
-RUN --mount=type=bind,source=src,target=src \
+RUN --mount=type=cache,target=target \
+    --mount=type=bind,source=src,target=src \
     --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
     --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
-    cargo build --release
+    cargo build --release && cp target/release/appsignal-kubernetes appsignal-kubernetes
 
 FROM alpine:3.20.3
 
-COPY --from=build /target/release/appsignal-kubernetes /appsignal-kubernetes
+COPY --from=build /appsignal-kubernetes /appsignal-kubernetes
 
 CMD ["/appsignal-kubernetes"]

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: appsignal-kubernetes-service-account
       containers:
       - name: appsignal-kubernetes
-        image: appsignal/appsignal-kubernetes:0.1.0
+        image: appsignal/appsignal-kubernetes:0.2.0
         imagePullPolicy: IfNotPresent
         env:
         - name: APPSIGNAL_API_KEY

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel="1.75.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,22 +24,13 @@ impl AppsignalMetric {
         metric_name: &str,
         tags: HashMap<String, String>,
         value: &serde_json::Value,
-    ) -> AppsignalMetric {
-        // See if we can use value
-        let value = match value {
-            Value::Number(value) => match value.as_f64() {
-                Some(value) => value as f32,
-                None => 0.0,
-            },
-            _ => 0.0,
-        };
-
-        AppsignalMetric {
+    ) -> Option<AppsignalMetric> {
+        value.as_f64().map(|value| Self {
             name: metric_name.to_string(),
             metric_type: "gauge".to_string(),
-            value,
+            value: value as f32,
             tags,
-        }
+        })
     }
 }
 
@@ -63,39 +54,14 @@ async fn run() -> Result<(), Error> {
     let mut out = Vec::new();
 
     for node in nodes {
-        let name = node.name_any();
-        let url = format!("/api/v1/nodes/{}/proxy/stats/summary", name);
+        let url = format!("/api/v1/nodes/{}/proxy/stats/summary", node.name_any());
 
         let kube_request = Request::get(url).body(Default::default())?;
         let kube_response = kube_client
             .request::<serde_json::Value>(kube_request)
             .await?;
 
-        if let Some(pods) = kube_response["pods"].as_array() {
-            for pod in pods {
-                extract_pod_metrics(
-                    pod,
-                    pod["podRef"]["name"]
-                        .as_str()
-                        .expect("Could not extract pod name"),
-                    &mut out,
-                );
-
-                if let Some(volumes) = pod["volume"].as_array() {
-                    for volume in volumes {
-                        extract_volume_metrics(
-                            volume,
-                            volume["name"]
-                                .as_str()
-                                .expect("Could not extract volume name"),
-                            &mut out,
-                        );
-                    }
-                }
-            }
-        };
-
-        extract_node_metrics(kube_response, &name, &mut out);
+        extract_metrics(&kube_response, &mut out);
     }
 
     let json = serde_json::to_string(&out).expect("Could not serialize JSON");
@@ -120,112 +86,30 @@ async fn run() -> Result<(), Error> {
     Ok(())
 }
 
-fn extract_pod_metrics(results: &Value, pod_name: &str, out: &mut Vec<AppsignalMetric>) {
-    for (metric_name, metric_value) in [
-        (
-            "pod_cpu_usage_nano_cores",
-            &results["cpu"]["usageNanoCores"],
-        ),
-        (
-            "pod_cpu_usage_core_nano_seconds",
-            &results["cpu"]["usageCoreNanoSeconds"],
-        ),
-        (
-            "pod_memory_working_set_bytes",
-            &results["memory"]["workingSetBytes"],
-        ),
-        (
-            "pod_swap_available_bytes",
-            &results["swap"]["swapAvailableBytes"],
-        ),
-        ("pod_swap_usage_bytes", &results["swap"]["swapUsageBytes"]),
-    ] {
-        let mut tags = HashMap::with_capacity(1);
-        tags.insert("pod".to_owned(), pod_name.to_owned());
-        out.push(AppsignalMetric::new(metric_name, tags, metric_value));
-    }
+fn extract_metrics(kube_response: &Value, out: &mut Vec<AppsignalMetric>) {
+    extract_node_metrics(&kube_response["node"], out);
+
+    if let Some(pods) = kube_response["pods"].as_array() {
+        for pod in pods {
+            extract_pod_metrics(pod, out);
+
+            if let Some(volumes) = pod["volume"].as_array() {
+                for volume in volumes {
+                    extract_volume_metrics(volume, out);
+                }
+            }
+        }
+    };
 }
 
-fn extract_node_metrics(results: Value, node_name: &str, out: &mut Vec<AppsignalMetric>) {
-    for (metric_name, metric_value) in [
-        (
-            "node_cpu_usage_nano_cores",
-            &results["node"]["cpu"]["usageNanoCores"],
-        ),
-        (
-            "node_cpu_usage_core_nano_seconds",
-            &results["node"]["cpu"]["usageCoreNanoSeconds"],
-        ),
-        (
-            "node_memory_available_bytes",
-            &results["node"]["memory"]["availableBytes"],
-        ),
-        (
-            "node_memory_usage_bytes",
-            &results["node"]["memory"]["usageBytes"],
-        ),
-        (
-            "node_memory_working_set_bytes",
-            &results["node"]["memory"]["workingSetBytes"],
-        ),
-        (
-            "node_memory_rss_bytes",
-            &results["node"]["memory"]["rssBytes"],
-        ),
-        (
-            "node_memory_page_faults",
-            &results["node"]["memory"]["pageFaults"],
-        ),
-        (
-            "node_memory_major_page_faults",
-            &results["node"]["memory"]["majorPageFaults"],
-        ),
-        (
-            "node_network_rx_bytes",
-            &results["node"]["network"]["rxBytes"],
-        ),
-        (
-            "node_network_rx_errors",
-            &results["node"]["network"]["rxErrors"],
-        ),
-        (
-            "node_network_tx_bytes",
-            &results["node"]["network"]["txBytes"],
-        ),
-        (
-            "node_network_tx_errors",
-            &results["node"]["network"]["txErrors"],
-        ),
-        (
-            "node_fs_available_bytes",
-            &results["node"]["fs"]["availableBytes"],
-        ),
-        (
-            "node_fs_capacity_bytes",
-            &results["node"]["fs"]["capacityBytes"],
-        ),
-        ("node_fs_used_bytes", &results["node"]["fs"]["usedBytes"]),
-        ("node_fs_inodes_free", &results["node"]["fs"]["inodesFree"]),
-        ("node_fs_inodes", &results["node"]["fs"]["inodes"]),
-        ("node_fs_inodes_used", &results["node"]["fs"]["inodesUsed"]),
-        ("node_rlimit_maxpid", &results["node"]["rlimit"]["maxpid"]),
-        ("node_rlimit_curproc", &results["node"]["rlimit"]["curproc"]),
-        (
-            "node_swap_available_bytes",
-            &results["node"]["swap"]["swapAvailableBytes"],
-        ),
-        (
-            "node_swap_usage_bytes",
-            &results["node"]["swap"]["swapUsageBytes"],
-        ),
-    ] {
-        let mut tags = HashMap::with_capacity(1);
-        tags.insert("node".to_owned(), node_name.to_owned());
-        out.push(AppsignalMetric::new(metric_name, tags, metric_value));
-    }
-}
+fn extract_volume_metrics(results: &Value, out: &mut Vec<AppsignalMetric>) {
+    let volume_name = if let Some(name) = results["name"].as_str() {
+        name
+    } else {
+        eprintln!("Could not extract volume name");
+        return;
+    };
 
-fn extract_volume_metrics(results: &Value, volume_name: &str, out: &mut Vec<AppsignalMetric>) {
     for (metric_name, metric_value) in [
         ("volume_available_bytes", &results["availableBytes"]),
         ("volume_capacity_bytes", &results["capacityBytes"]),
@@ -236,7 +120,129 @@ fn extract_volume_metrics(results: &Value, volume_name: &str, out: &mut Vec<Apps
     ] {
         let mut tags = HashMap::with_capacity(1);
         tags.insert("volume".to_owned(), volume_name.to_owned());
-        out.push(AppsignalMetric::new(metric_name, tags, metric_value));
+
+        if let Some(metric) = AppsignalMetric::new(metric_name, tags, metric_value) {
+            out.push(metric);
+        }
+    }
+}
+
+fn extract_pod_metrics(pod_results: &Value, out: &mut Vec<AppsignalMetric>) {
+    let pod_name = if let Some(name) = pod_results["podRef"]["name"].as_str() {
+        name
+    } else {
+        eprintln!("Could not extract pod name");
+        return;
+    };
+
+    for (metric_name, metric_value) in [
+        (
+            "pod_cpu_usage_nano_cores",
+            &pod_results["cpu"]["usageNanoCores"],
+        ),
+        (
+            "pod_cpu_usage_core_nano_seconds",
+            &pod_results["cpu"]["usageCoreNanoSeconds"],
+        ),
+        (
+            "pod_memory_working_set_bytes",
+            &pod_results["memory"]["workingSetBytes"],
+        ),
+        (
+            "pod_swap_available_bytes",
+            &pod_results["swap"]["swapAvailableBytes"],
+        ),
+        (
+            "pod_swap_usage_bytes",
+            &pod_results["swap"]["swapUsageBytes"],
+        ),
+    ] {
+        let mut tags = HashMap::with_capacity(1);
+        tags.insert("pod".to_owned(), pod_name.to_owned());
+
+        if let Some(metric) = AppsignalMetric::new(metric_name, tags, metric_value) {
+            out.push(metric);
+        }
+    }
+}
+
+fn extract_node_metrics(node_results: &Value, out: &mut Vec<AppsignalMetric>) {
+    let node_name = if let Some(name) = node_results["nodeName"].as_str() {
+        name
+    } else {
+        eprintln!("Could not extract node name");
+        return;
+    };
+
+    for (metric_name, metric_value) in [
+        (
+            "node_cpu_usage_nano_cores",
+            &node_results["cpu"]["usageNanoCores"],
+        ),
+        (
+            "node_cpu_usage_core_nano_seconds",
+            &node_results["cpu"]["usageCoreNanoSeconds"],
+        ),
+        (
+            "node_memory_available_bytes",
+            &node_results["memory"]["availableBytes"],
+        ),
+        (
+            "node_memory_usage_bytes",
+            &node_results["memory"]["usageBytes"],
+        ),
+        (
+            "node_memory_working_set_bytes",
+            &node_results["memory"]["workingSetBytes"],
+        ),
+        ("node_memory_rss_bytes", &node_results["memory"]["rssBytes"]),
+        (
+            "node_memory_page_faults",
+            &node_results["memory"]["pageFaults"],
+        ),
+        (
+            "node_memory_major_page_faults",
+            &node_results["memory"]["majorPageFaults"],
+        ),
+        ("node_network_rx_bytes", &node_results["network"]["rxBytes"]),
+        (
+            "node_network_rx_errors",
+            &node_results["network"]["rxErrors"],
+        ),
+        ("node_network_tx_bytes", &node_results["network"]["txBytes"]),
+        (
+            "node_network_tx_errors",
+            &node_results["network"]["txErrors"],
+        ),
+        (
+            "node_fs_available_bytes",
+            &node_results["fs"]["availableBytes"],
+        ),
+        (
+            "node_fs_capacity_bytes",
+            &node_results["fs"]["capacityBytes"],
+        ),
+        ("node_fs_used_bytes", &node_results["fs"]["usedBytes"]),
+        ("node_fs_inodes_free", &node_results["fs"]["inodesFree"]),
+        ("node_fs_inodes", &node_results["fs"]["inodes"]),
+        ("node_fs_inodes_used", &node_results["fs"]["inodesUsed"]),
+        ("node_rlimit_maxpid", &node_results["rlimit"]["maxpid"]),
+        ("node_rlimit_curproc", &node_results["rlimit"]["curproc"]),
+        (
+            "node_swap_available_bytes",
+            &node_results["swap"]["swapAvailableBytes"],
+        ),
+        (
+            "node_swap_usage_bytes",
+            &node_results["swap"]["swapUsageBytes"],
+        ),
+    ] {
+        let mut tags = HashMap::with_capacity(1);
+        tags.insert("node".to_owned(), node_name.to_owned());
+
+        if let Some(metric) = AppsignalMetric::new(metric_name, tags, metric_value) {
+            out.push(metric);
+        }
     }
 }
 
@@ -246,62 +252,149 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn extract_node_metrics_with_empty_results() {
+    fn extract_metrics_without_response() {
+      let mut out = Vec::new();
+      extract_metrics(
+          &json!({}),
+          &mut out,
+      );
+      assert_eq!(out.len(), 0);
+    }
+
+    #[test]
+    fn extract_metrics_with_response() {
+      let mut out = Vec::new();
+      extract_metrics(
+          &json!({
+            "node": {
+              "nodeName": "some_node",
+              "cpu": {
+               "time": "2024-03-29T12:21:36Z",
+               "usageNanoCores": 111111111,
+              },
+            },
+            "pods": [
+              {
+                "podRef": {
+                    "name": "some_pod"
+                },
+                "cpu": {
+                 "time": "2024-03-29T12:21:36Z",
+                 "usageNanoCores": 222222222,
+                },
+              },
+              {
+                "podRef": {
+                    "name": "other_pod"
+                },
+                "cpu": {
+                 "time": "2024-03-29T12:21:36Z",
+                 "usageNanoCores": 333333333,
+                },
+                "volume": [
+                  {
+                    "name": "some_volume",
+                    "availableBytes": 444444444,
+                  },
+                  {
+                    "name": "other_volume",
+                    "availableBytes": 555555555,
+                  },
+                ],
+              },
+            ],
+          }),
+          &mut out,
+      );
+      assert_eq!(out.len(), 5);
+      assert!(out.contains(&AppsignalMetric::new(
+          "node_cpu_usage_nano_cores",
+          HashMap::from([("node".to_string(), "some_node".to_string())]),
+          &json!(111111111)
+      ).expect("Could not create metric")), "node_cpu_usage_nano_cores not found");
+      assert!(out.contains(&AppsignalMetric::new(
+          "pod_cpu_usage_nano_cores",
+          HashMap::from([("pod".to_string(), "some_pod".to_string())]),
+          &json!(222222222)
+      ).expect("Could not create metric")), "pod_cpu_usage_nano_cores for some_pod not found");
+      assert!(out.contains(&AppsignalMetric::new(
+          "pod_cpu_usage_nano_cores",
+          HashMap::from([("pod".to_string(), "other_pod".to_string())]),
+          &json!(333333333)
+      ).expect("Could not create metric")), "pod_cpu_usage_nano_cores for other_pod not found");
+      assert!(out.contains(&AppsignalMetric::new(
+          "volume_available_bytes",
+          HashMap::from([("volume".to_string(), "some_volume".to_string())]),
+          &json!(444444444)
+      ).expect("Could not create metric")), "volume_available_bytes for some_volume not found");
+      assert!(out.contains(&AppsignalMetric::new(
+          "volume_available_bytes",
+          HashMap::from([("volume".to_string(), "other_volume".to_string())]),
+          &json!(555555555)
+      ).expect("Could not create metric")), "volume_available_bytes for other_volume not found");
+    }
+
+    #[test]
+    fn extract_node_metrics_without_results() {
         let mut out = Vec::new();
-        extract_node_metrics(json!([]), "node", &mut out);
-        assert_eq!(
-            AppsignalMetric::new(
-                "node_cpu_usage_nano_cores",
-                HashMap::from([("node".to_string(), "node".to_string())]),
-                &json!(0.0)
-            ),
-            out[0]
+        extract_node_metrics(&json!({}), &mut out);
+        assert_eq!(out.len(), 0);
+    }
+
+    #[test]
+    fn extract_node_metrics_missing_name() {
+        let mut out = Vec::new();
+        extract_node_metrics(
+            &json!({
+              "cpu": {
+               "time": "2024-03-29T12:21:36Z",
+               "usageNanoCores": 232839439,
+               "usageCoreNanoSeconds": 1118592000000 as u64
+              },
+            }),
+            &mut out,
         );
+
+        assert_eq!(out.len(), 0);
     }
 
     #[test]
     fn extract_node_metrics_with_results() {
         let mut out = Vec::new();
         extract_node_metrics(
-            json!({
-             "node": {
+            &json!({
+              "nodeName": "some_node",
               "cpu": {
                "time": "2024-03-29T12:21:36Z",
                "usageNanoCores": 232839439,
                "usageCoreNanoSeconds": 1118592000000 as u64
               },
-            }
             }),
-            "node",
             &mut out,
         );
 
         assert_eq!(
             AppsignalMetric::new(
                 "node_cpu_usage_nano_cores",
-                HashMap::from([("node".to_string(), "node".to_string())]),
+                HashMap::from([("node".to_string(), "some_node".to_string())]),
                 &json!(232839439)
-            ),
+            )
+            .expect("Could not create metric"),
             out[0]
         );
+
+        assert_eq!(out.len(), 2);
     }
 
     #[test]
-    fn extract_pod_metrics_with_empty_results() {
+    fn extract_pod_metrics_without_results() {
         let mut out = Vec::new();
-        extract_pod_metrics(&json!([]), "pod", &mut out);
-        assert_eq!(
-            AppsignalMetric::new(
-                "pod_cpu_usage_nano_cores",
-                HashMap::from([("pod".to_string(), "pod".to_string())]),
-                &json!(0.0)
-            ),
-            out[0]
-        );
+        extract_pod_metrics(&json!({}), &mut out);
+        assert_eq!(out.len(), 0);
     }
 
     #[test]
-    fn extract_pod_metrics_with_results() {
+    fn extract_pod_metrics_missing_name() {
         let mut out = Vec::new();
         extract_pod_metrics(
             &json!({
@@ -311,32 +404,62 @@ mod tests {
                "usageCoreNanoSeconds": 1118592000000 as u64
               },
             }),
-            "pod",
+            &mut out,
+        );
+
+        assert_eq!(out.len(), 0);
+    }
+
+    #[test]
+    fn extract_pod_metrics_with_results() {
+        let mut out = Vec::new();
+        extract_pod_metrics(
+            &json!({
+              "podRef": {
+                  "name": "some_pod"
+              },
+              "cpu": {
+               "time": "2024-03-29T12:21:36Z",
+               "usageNanoCores": 232839439,
+               "usageCoreNanoSeconds": 1118592000000 as u64
+              },
+            }),
             &mut out,
         );
 
         assert_eq!(
             AppsignalMetric::new(
                 "pod_cpu_usage_nano_cores",
-                HashMap::from([("pod".to_string(), "pod".to_string())]),
+                HashMap::from([("pod".to_string(), "some_pod".to_string())]),
                 &json!(232839439)
-            ),
+            )
+            .expect("Could not create metric"),
             out[0]
         );
+
+        assert_eq!(out.len(), 2);
     }
 
     #[test]
-    fn extract_volume_metrics_with_empty_results() {
+    fn extract_volume_metrics_without_results() {
         let mut out = Vec::new();
-        extract_volume_metrics(&json!([]), "volume", &mut out);
-        assert_eq!(
-            AppsignalMetric::new(
-                "volume_fs_available_bytes",
-                HashMap::from([("pod".to_string(), "volume".to_string())]),
-                &json!(0.0)
-            ),
-            out[0]
+        extract_volume_metrics(&json!({}), &mut out);
+
+        assert_eq!(out.len(), 0);
+    }
+
+    #[test]
+    fn extract_volume_metrics_missing_name() {
+        let mut out = Vec::new();
+        extract_volume_metrics(
+            &json!({
+              "availableBytes": 232839439,
+              "capacityBytes": 1118592000000 as u64,
+            }),
+            &mut out,
         );
+
+        assert_eq!(out.len(), 0);
     }
 
     #[test]
@@ -344,19 +467,23 @@ mod tests {
         let mut out = Vec::new();
         extract_volume_metrics(
             &json!({
-              "availableBytes": 232839439
+              "name": "some_volume",
+              "availableBytes": 232839439,
+              "capacityBytes": 1118592000000 as u64,
             }),
-            "volume",
             &mut out,
         );
 
         assert_eq!(
             AppsignalMetric::new(
                 "volume_available_bytes",
-                HashMap::from([("volume".to_string(), "volume".to_string())]),
+                HashMap::from([("volume".to_string(), "some_volume".to_string())]),
                 &json!(232839439)
-            ),
+            )
+            .expect("Could not create metric"),
             out[0]
         );
+
+        assert_eq!(out.len(), 2);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,8 @@ async fn run(metrics_url: &Url) -> Result<(), Error> {
         extract_metrics(&kube_response, &mut out);
     }
 
+    let metrics_count = out.len();
+
     let json = serde_json::to_string(&out).expect("Could not serialize JSON");
 
     let reqwest_client = Client::builder().timeout(Duration::from_secs(30)).build()?;
@@ -108,7 +110,11 @@ async fn run(metrics_url: &Url) -> Result<(), Error> {
         .send()
         .await?;
 
-    println!("Done: {:?}", appsignal_response);
+    println!(
+        "Sent {} metrics to AppSignal: status code {:?}",
+        metrics_count,
+        appsignal_response.status()
+    );
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,13 +44,15 @@ impl AppsignalMetric {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() {
     let duration = Duration::new(60, 0);
     let mut interval = tokio::time::interval(duration);
 
     loop {
         interval.tick().await;
-        run().await.expect("Failed to extract metrics.")
+        if let Err(error) = run().await {
+            eprintln!("Failed to extract metrics: {}", &error);
+        };
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,7 @@ fn extract_node_metrics(results: Value, node_name: &str, out: &mut Vec<Appsignal
             &results["node"]["fs"]["availableBytes"],
         ),
         (
-            "node_s_capacity_bytes",
+            "node_fs_capacity_bytes",
             &results["node"]["fs"]["capacityBytes"],
         ),
         ("node_fs_used_bytes", &results["node"]["fs"]["usedBytes"]),


### PR DESCRIPTION
Requested by a customer; see [Intercom conversation](https://app.intercom.com/a/inbox/yzor8gyw/inbox/conversation/16410700363805) and [Slack conversation](https://appsignal.slack.com/archives/C7XHXQ7N0/p1727092126423819).

### [Fix `node_fs_capacity_bytes` metric name](https://github.com/appsignal/appsignal-kubernetes/commit/42f0db86778ebac9d32d3c972ac86710366ec712)

### [Add the Rust version to the `.tool_versions` file](https://github.com/appsignal/appsignal-kubernetes/commit/adf22cf6322d7fa0c32b2ad00a02da118679d29c)

The project will not build on versions lower than `1.75.0`, due to
the `kube-derive` version it depends on.

### [Extract volume metrics](https://github.com/appsignal/appsignal-kubernetes/commit/b6c964f60aaf485f0ecb6166e87c5341395dad93)

Extract the volume metrics from each pod, if any.

### [Do not crash when failing to extract metrics](https://github.com/appsignal/appsignal-kubernetes/commit/73c51aa9534884d8aae39987655d2de48c265b48)

Instead, write an error message to standard error, containing the
error obtained from the `run()` function, then loop again.

### [Ignore nameless entities](https://github.com/appsignal/appsignal-kubernetes/commit/2bfd029d7cac6e3c028604e423cf6ab66e17f052)

Do not emit metrics for a node, pod or volume if it doesn't have a
name. In practice, this only happens for volumes.

When a metric is missing, instead of emitting a metric with a value
of zero, do not emit a metric at all.

Re-structure the metric extraction functions to be able to test the
way in which the overall JSON is traversed, rather than just how
metrics are extracted from each section of it.

### [Crash if `APPSIGNAL_API_KEY` is not set](https://github.com/appsignal/appsignal-kubernetes/commit/2f51129cc39abed95e28ad35226746325a0dc2b6)

A panic in an asychronous task becomes a `JoinError` when awaited.
As we now print the errors returned by `run()`, they will no longer
cause the thread to panic. This behaviour is correct for errors
related to the network requests, which can be assumed to be transient,
but the process should actually crash if `APPSIGNAL_API_KEY` is not
set.

Move the creation of the URL that the metrics are sent to to a
separate function, as to call it in `main()` instead of `run()`,
causing the process to crash if the URL fails to be created because
`APPSIGNAL_API_KEY` is not set.

### [Do not send repeated metrics](https://github.com/appsignal/appsignal-kubernetes/commit/13eb6036fcc91e9566858de20371f5b7645993e4)

If several pods mount the same volume, avoid sending the same metric
more than once by collecting the metrics into a `HashSet` keyed by
the metric name and its tags.

### [Send metric values as `f64`](https://github.com/appsignal/appsignal-kubernetes/commit/6db0e596cde222c77be704addfa3f277316f21dd)

Some of the values that we send are big integers such as nanoseconds,
for which `f32` quickly incurs a loss of precision (e.g. the next
`f32` after `444444400` is `444444450`). Use `f64` instead.

Add a test that ensures that the serialised value has enough precision.

### [Fix `TAG` with BSD-style `tr` command](https://github.com/appsignal/appsignal-kubernetes/commit/d628e81f7c855d06a7f53ed95abffff0768bb0a3)

In macOS, the `tr` command does not support long options (`--delete`)
or character ranges (`a-z`). Since we seemingly intend to remove the
`v` at the beginning of the tag name, let's do that.

### [Do not print API key to standard output](https://github.com/appsignal/appsignal-kubernetes/commit/d62d973db91d2b6abda165aacf93075462de5fcc)

Avoid printing the entire response object, including the API key used
in the request to AppSignal, to standard output. Instead, print the
status code and the number of metrics that were delivered to AppSignal.

### [Bump version to 0.2.0](https://github.com/appsignal/appsignal-kubernetes/commit/bb1049b99d06a10e6a1335a42414f9c1dc9bb3c5)

### [Load `make build` builds to Docker](https://github.com/appsignal/appsignal-kubernetes/commit/4d0581829e08082a69ee5e4492178ea8c4f7b200)

This makes it easier to test them using Kubernetes on Docker Desktop.

### [Use cache mount to speed up builds](https://github.com/appsignal/appsignal-kubernetes/commit/57a5ba2722eed32a2fd708e2161cef3cadfb42e1)

Each build was re-downloading and re-compiling all dependencies.
Use a `cache` type mount for the `target` folder to keep the
compilation artifacts around between builds.