### PR TITLE
Reduce build artifact size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ kube = { version = "0.89", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.21", features = ["latest"] }
 http = "1.0"
 serde = "*"
+
+[profile.release]
+strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ http = "1.0"
 serde = "*"
 
 [profile.release]
+lto = true
 strip = true


### PR DESCRIPTION
## Strip symbols from the release artifact

By default, Rust doesn't strip the tags from the release artifacts. Set the `strip` config in release profile to true, which is the same as "symbols".

https://doc.rust-lang.org/cargo/reference/profiles.html#strip

This reduces the file size by a couple MB.

Without strip:

- amd64-unknown-linux-musl/appsignal-kubernetes: 13M
- arm64-unknown-linux-musl/appsignal-kubernetes: 12M

With strip:

- amd64-unknown-linux-musl/appsignal-kubernetes: 10M
- arm64-unknown-linux-musl/appsignal-kubernetes: 8.7M

## Enable link time optimizations for release build

Optimize the release artifact size further by enabling lto by setting the config option in the release profile to true, which is the same as "fat".

> Performs “fat” LTO which attempts to perform optimizations across all
> crates within the dependency graph.

https://doc.rust-lang.org/cargo/reference/profiles.html#lto

This reduces the file size by a couple MB.

Without strip, without lto:

- amd64-unknown-linux-musl/appsignal-kubernetes: 13M
- arm64-unknown-linux-musl/appsignal-kubernetes: 12M

With strip (previous commit):

- amd64-unknown-linux-musl/appsignal-kubernetes: 10M
- arm64-unknown-linux-musl/appsignal-kubernetes: 8.7M

With strip and lto:

- amd64-unknown-linux-musl/appsignal-kubernetes: 8.3M
- arm64-unknown-linux-musl/appsignal-kubernetes: 7.0M
