### PR TITLE
Reduce published Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:alpine
+FROM rust:1.75.0-alpine3.19
 
 RUN apk add --no-cache clang libressl-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.75.0-alpine3.19
+FROM rust:1.75.0-alpine3.19 AS build
 
 RUN apk add --no-cache clang libressl-dev
 
@@ -6,5 +6,9 @@ RUN --mount=type=bind,source=src,target=src \
     --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
     --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
     cargo build --release
+
+FROM alpine:3.20.3
+
+COPY --from=build /target/release/appsignal-kubernetes /target/release/appsignal-kubernetes
 
 CMD ["/target/release/appsignal-kubernetes"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN --mount=type=bind,source=src,target=src \
 
 FROM alpine:3.20.3
 
-COPY --from=build /target/release/appsignal-kubernetes /target/release/appsignal-kubernetes
+COPY --from=build /target/release/appsignal-kubernetes /appsignal-kubernetes
 
-CMD ["/target/release/appsignal-kubernetes"]
+CMD ["/appsignal-kubernetes"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG=$(shell git describe --tags --abbrev=0 | tr --delete a-z)
+TAG=$(shell git describe --tags --abbrev=0 | tr -d v)
 
 .PHONY: build push setup
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ TAG=$(shell git describe --tags --abbrev=0 | tr -d v)
 build:
 	docker buildx build \
           --builder=appsignal-container \
+          --load \
           --tag appsignal/appsignal-kubernetes:$(TAG) \
           --tag appsignal/appsignal-kubernetes:latest \
           .

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ TAG=$(shell git describe --tags --abbrev=0 | tr -d v)
 
 build:
 	docker buildx build \
+          --platform linux/amd64,linux/arm64 \
           --builder=appsignal-container \
           --load \
           --tag appsignal/appsignal-kubernetes:$(TAG) \

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ It extracts the following metrics from the `/api/v1/nodes/<NODE>/proxy/stats/sum
 After installing AppSignal for Kubernetes into a cluster, an Automated Dashboard automatically appears on AppSignal showing you an overview of the nodes in your Kubernetes cluster.
 The reported metrics can also be used to create custom dashboards through the [Dashboard and Graph Builder](https://appsignal.com/redirect-to/app?to=dashboard&overlay=dashboardForm).
 
+## Development
+
+### Publish new releases
+
+To publish a new release, follow these steps:
+
+- Tag a new release in Git: `git tag vx.x.x`
+- Run the publish task: `make push`
+
+The last tag will used as the new version published to the [appsignal/appsignal-kubernetes](https://hub.docker.com/repository/docker/appsignal/appsignal-kubernetes/tags) image on Docker Hub.
+
 ## Support
 
 Please don't hesitate to [contact us](mailto:support@appsignal.com) if we can assist you in getting AppSignal for Kubernetes setup.


### PR DESCRIPTION
Some PRs cherry-picked from PR #4 to make it work locally.

---

## Fix `TAG` with BSD-style `tr` command

In macOS, the `tr` command does not support long options (`--delete`) or character ranges (`a-z`). Since we seemingly intend to remove the `v` at the beginning of the tag name, let's do that.

## Load `make build` builds to Docker

This makes it easier to test them using Kubernetes on Docker Desktop.

## Build local images for both supported platforms

This makes it easier to test if it works for both platforms without having to publish a new version, or publish a version to a test repository.

## Lock the base image to a more specific tag

The alpine tag gets overwritten on every release of the rust image. Use a more specific tag that should change less or not at all to make sure we're always publishing from the same base.

Rust version based on the version selected in PR #4.

## Reduce published image size

I noticed we ship the image with the `rust:alpine` image as a base. This means we ship the entire Rust language, all dependencies, and compilation caches and artifacts with our releases as well. Our image size is therefore 559.38 MB according to Docker Hub. This was because the `Dockerfile` did two things at once:

- Build the project with Cargo
- And be the thing we publish to Docker Hub

Use a multi-stage build to not include the entire Rust language base image in the published image, reducing the image size from 559.38 MB to around 7 MB (including the size reducing improvements from PR #6).

The published image will only have the alpine image as a base. It includes the build artifact from the previous stage by way of copying it from the first stage to the second stage. This works for the multiple platforms we publish.

## Move the executable to the root directory

Don't keep the previous directory structure that kept the project structure in mind, but put it at the root of the image.

## Add publish instructions to the README

I couldn't find how to publish new images, so I added it to the README.


## Screenshots

The current released image:
![image](https://github.com/user-attachments/assets/5675a453-5109-4f1e-9ab5-f5992c9b3105)

The test image released with this process:
![image](https://github.com/user-attachments/assets/32076c8e-2068-4095-bff1-dd6655444282)
