### PR TITLE
Use independent cache mounts per platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM rust:1.75.0-alpine3.19 AS build
 
+ARG TARGETPLATFORM
+
 RUN apk add --no-cache clang libressl-dev
 
-RUN --mount=type=cache,target=target \
+RUN --mount=type=cache,target=target,id=cache-${TARGETPLATFORM} \
     --mount=type=bind,source=src,target=src \
     --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
     --mount=type=bind,source=Cargo.lock,target=Cargo.lock \


### PR DESCRIPTION
Will merge without review for the 0.2.0 release.

---

When building for several platforms, both builds attempt to use the
same `target` cache volume. Not only does this essentially force the
builds to be sequential, as `cargo` takes a lock on the folder, but
the artifacts compiled for one platform cannot be re-used for the
other in future builds, in practice forcing the build to start from
scratch as if no cache were present.

Use the `id` mount attribute and the `$TARGETPLATFORM` environment
variable to have different cache volumes mounted in the same path
for each platform.