### PR TITLE
Pass build platforms in environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 TAG=$(shell ./script/read_version.sh)
+PLATFORMS ?= "linux/amd64,linux/arm64"
 
 .PHONY: build push setup
 
 build:
 	docker buildx build \
-          --platform linux/amd64,linux/arm64 \
+          --platform $(PLATFORMS) \
           --builder=appsignal-container \
           --load \
           --tag appsignal/appsignal-kubernetes:$(TAG) \


### PR DESCRIPTION
On my Intel machine, the ARM build gets stuck on building the final artifact, using 100% CPU and slowly increasing memory use forever.

I will look into sorting this out, but for now, being able to pass `PLATFORMS=linux/amd64` provides a workaround for testing it locally.

I have also made `TAG` into an environment variable as that allows for builds to be given different tags -- this makes it easier to check that your local Kubernetes isn't running a stale build.