### PR TITLE
Add Mono for publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG=$(shell git describe --tags --abbrev=0 | tr -d v)
+TAG=$(shell ./script/read_version.sh)
 
 .PHONY: build push setup
 

--- a/mono.yml
+++ b/mono.yml
@@ -1,0 +1,13 @@
+---
+language: "custom"
+repo: "https://github.com/appsignal/appsignal-kubernetes/"
+build:
+  command: "make build"
+publish:
+  command: "make push"
+test:
+  command: "cargo test"
+
+read_version: "script/read_version.sh"
+write_version: "script/write_version.sh"
+version_scheme: "semver"

--- a/script/read_version.sh
+++ b/script/read_version.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+grep -e '^version =' Cargo.toml | cut -d '"' -f 2

--- a/script/write_version.sh
+++ b/script/write_version.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+VERSION=$1
+
+sed -i '' -e 's/^version = ".*"$/version = "'$VERSION'"/' Cargo.toml
+sed -i '' -e 's|image: appsignal/appsignal-kubernetes:.*$|image: appsignal/appsignal-kubernetes:'$VERSION'|' deployment.yaml


### PR DESCRIPTION
Adds Mono for the publishing process. Running `mono publish` will automatically bump up the version number according to the changesets, compile the changesets into a changelog and publish the package with the bumped version number.