### PR TITLE
Update CI workflow events

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,19 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+      - develop
   pull_request:
-  workflow_dispatch:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  schedule:
+    - cron: 0 0 * * 1-5
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ !contains(github.ref, 'main')}}"
 
 jobs:
   ci:


### PR DESCRIPTION
Trigger a CI workflow build via push only for the main and develop branches. This avoids the CI always doing to build twice when pushed and making a PR for a branch.

Specify the specific PR events to trigger on.

Run the CI automatically every week day so we can be alerted if a build suddenly fails when we're not working on it.

Cancel builds in progress immediately when a new change is pushed on a branch, except for the main branch.

[skip changeset]
[skip review]