### PR TITLE
Update clippy config in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,5 +23,5 @@ jobs:
       - uses: actions/checkout@v4
       - run: cargo build --verbose
       - run: cargo test --verbose
-      - run: cargo clippy --verbose
+      - run: cargo clippy --verbose --tests --all-targets --all-features -- -D warnings
       - run: cargo fmt --verbose

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ impl AppsignalMetric {
         value.as_f64().map(|value| Self {
             name: metric_name.to_string(),
             metric_type: "gauge".to_string(),
-            value: value as f64,
+            value,
             tags,
         })
     }
@@ -202,7 +202,7 @@ fn extract_pod_metrics(
         }
     }
 
-    return Some(pod_name.to_owned());
+    Some(pod_name.to_owned())
 }
 
 fn extract_node_metrics(node_results: &Value, out: &mut HashSet<AppsignalMetricKey>) {
@@ -419,7 +419,7 @@ mod tests {
               "cpu": {
                "time": "2024-03-29T12:21:36Z",
                "usageNanoCores": 232839439,
-               "usageCoreNanoSeconds": 1118592000000 as u64
+               "usageCoreNanoSeconds": 1118592000000_u64
               },
             }),
             &mut out,
@@ -437,7 +437,7 @@ mod tests {
               "cpu": {
                "time": "2024-03-29T12:21:36Z",
                "usageNanoCores": 232839439,
-               "usageCoreNanoSeconds": 1118592000000 as u64
+               "usageCoreNanoSeconds": 1118592000000_u64
               },
             }),
             &mut out,
@@ -457,7 +457,7 @@ mod tests {
             AppsignalMetric::new(
                 "node_cpu_usage_core_nano_seconds",
                 BTreeMap::from([("node".to_string(), "some_node".to_string())]),
-                &json!(1118592000000 as u64),
+                &json!(1118592000000_u64),
             )
             .expect("Could not create metric"),
         );
@@ -480,7 +480,7 @@ mod tests {
               "cpu": {
                "time": "2024-03-29T12:21:36Z",
                "usageNanoCores": 232839439,
-               "usageCoreNanoSeconds": 1118592000000 as u64
+               "usageCoreNanoSeconds": 1118592000000_u64
               },
             }),
             &mut out,
@@ -500,7 +500,7 @@ mod tests {
               "cpu": {
                "time": "2024-03-29T12:21:36Z",
                "usageNanoCores": 232839439,
-               "usageCoreNanoSeconds": 1118592000000 as u64
+               "usageCoreNanoSeconds": 1118592000000_u64
               },
             }),
             &mut out,
@@ -520,7 +520,7 @@ mod tests {
             AppsignalMetric::new(
                 "pod_cpu_usage_core_nano_seconds",
                 BTreeMap::from([("pod".to_string(), "some_pod".to_string())]),
-                &json!(1118592000000 as u64),
+                &json!(1118592000000_u64),
             )
             .expect("Could not create metric"),
         );
@@ -542,7 +542,7 @@ mod tests {
         extract_volume_metrics(
             &json!({
               "availableBytes": 232839439,
-              "capacityBytes": 1118592000000 as u64,
+              "capacityBytes": 1118592000000_u64,
             }),
             "some_pod",
             &mut out,
@@ -558,7 +558,7 @@ mod tests {
             &json!({
               "name": "some_volume",
               "availableBytes": 232839439,
-              "capacityBytes": 1118592000000 as u64,
+              "capacityBytes": 1118592000000_u64,
             }),
             "some_pod",
             &mut out,
@@ -585,7 +585,7 @@ mod tests {
                     ("pod".to_string(), "some_pod".to_string()),
                     ("volume".to_string(), "some_volume".to_string()),
                 ]),
-                &json!(1118592000000 as u64),
+                &json!(1118592000000_u64),
             )
             .expect("Could not create metric"),
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,8 +35,8 @@ impl AppsignalMetric {
         })
     }
 
-    pub fn to_key(self) -> AppsignalMetricKey {
-        AppsignalMetricKey(self)
+    pub fn to_key(&self) -> AppsignalMetricKey {
+        AppsignalMetricKey(self.clone())
     }
 }
 


### PR DESCRIPTION
## Update clippy config in CI

- Ensure that the tests are also checked by clippy.
- Exit with an error code on warnings.
- Enable clippy for all targets.
- Test all the features (not that we have any, but it's good practice)

And fix most of the issues with `--fix`.

## Update AppsignalMetric to_key argument

Clone the self value because it gets transformed into a new value.

While the original code works, it can create confusing situations about ownership if the AppsignalMetric is used after `to_key` is called.

Pointed out by clippy in this rule:

https://rust-lang.github.io/rust-clippy/master/index.html#/wrong_self_convention

[skip changeset]