### PR TITLE
Report to different AppSignal apps using namespaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "appsignal-kubernetes"
-version = "0.2.0"
+version = "0.2.0-namespace-api-keys"
 dependencies = [
  "http",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appsignal-kubernetes"
-version = "0.2.0"
+version = "0.2.0-namespace-api-keys"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Rakefile
+++ b/Rakefile
@@ -117,7 +117,7 @@ task :publish => "build:target:all" do
     "--builder=#{BUILDX_NAME}",
     "--file=Dockerfile",
     "--platform=#{platforms.join(",")}",
-    "--tag #{DOCKER_IMAGE_NAME}:latest",
+    # "--tag #{DOCKER_IMAGE_NAME}:latest",
     "--tag #{tag}"
   ]
   options << "--push" unless ENV["PUBLISH_DRY_RUN"]

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: appsignal-kubernetes-service-account
       containers:
       - name: appsignal-kubernetes
-        image: appsignal/appsignal-kubernetes:0.2.0
+        image: appsignal/appsignal-kubernetes:0.2.0-namespace-api-keys
         imagePullPolicy: IfNotPresent
         env:
         - name: APPSIGNAL_API_KEY

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -23,6 +23,12 @@ spec:
             secretKeyRef:
               name: appsignal
               key: api-key
+        - name: APPSIGNAL_NAMESPACE_API_KEY_MAP
+          valueFrom:
+            secretKeyRef:
+              name: appsignal
+              key: namespace-api-key-map
+              optional: true
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,10 +124,9 @@ async fn run() -> Result<(), Error> {
         let json = serde_json::to_string(&metrics).expect("Could not serialize JSON");
 
         let reqwest_client = Client::builder().timeout(Duration::from_secs(30)).build()?;
-        let metrics_url = metrics_url_for_namespace(namespace.clone());
 
         let appsignal_response = reqwest_client
-            .post(metrics_url)
+            .post(metrics_url_for_namespace(namespace.clone()))
             .body(json.to_owned())
             .send()
             .await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,8 +71,25 @@ async fn main() {
     }
 }
 
-fn api_key_for_namespace(_namespace: String) -> String {
-    env::var("APPSIGNAL_API_KEY").expect("APPSIGNAL_API_KEY not set")
+fn api_key_for_namespace(namespace: String) -> String {
+    let mut api_keys = HashMap::new();
+    let namespace_api_key_map_string =
+        env::var("APPSIGNAL_NAMESPACE_API_KEY_MAP").unwrap_or("".to_owned());
+    let namespace_api_key_map_pairs = namespace_api_key_map_string.split(",").collect::<Vec<&str>>();
+
+    for pair in namespace_api_key_map_pairs {
+        match pair.split_once("=") {
+            Some((key, value)) => {
+                api_keys.insert(key, value);
+            }
+            None => ()
+        }
+    }
+
+    match api_keys.get(namespace.as_str()) {
+        Some(key) => key.to_string(),
+        None => env::var("APPSIGNAL_API_KEY").expect("APPSIGNAL_API_KEY not set")
+    }
 }
 
 fn metrics_url_for_namespace(namespace: String) -> Url {

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,10 +71,14 @@ async fn main() {
     }
 }
 
-fn must_metrics_url_from_env() -> Url {
+fn api_key_for_namespace(_namespace: String) -> String {
+    env::var("APPSIGNAL_API_KEY").expect("APPSIGNAL_API_KEY not set")
+}
+
+fn metrics_url_for_namespace(namespace: String) -> Url {
     let endpoint =
         env::var("APPSIGNAL_ENDPOINT").unwrap_or("https://appsignal-endpoint.net".to_owned());
-    let api_key = env::var("APPSIGNAL_API_KEY").expect("APPSIGNAL_API_KEY not set");
+    let api_key = api_key_for_namespace(namespace);
     let base = Url::parse(&endpoint).expect("Could not parse endpoint");
     let path = format!("metrics/json?api_key={}", api_key);
     base.join(&path).expect("Could not build request URL")
@@ -105,7 +109,7 @@ async fn run() -> Result<(), Error> {
         let reqwest_client = Client::builder().timeout(Duration::from_secs(30)).build()?;
 
         let appsignal_response = reqwest_client
-            .post(must_metrics_url_from_env())
+            .post(metrics_url_for_namespace(namespace.clone()))
             .body(json.to_owned())
             .send()
             .await?;


### PR DESCRIPTION
This is a work-in-progress patch to test support for reporting to multiple apps through using Kubernetes namespaces. By setting the `APPSIGNAL_NAMESPACE_API_KEY_MAP` environment variable to hold a frontend key per namespace (`namespace1=123abc,namespace2=abc123`), any node metrics for that specific namespace get posted to a different app in AppSignal. All non-node metrics, as well as metrics for namespaces not listed in the new environment variable, are pushed to the default app configured through the `APPSIGNAL_API_KEY` environment variable.

Closes #16.