### PR TITLE
Ensure timestamps are set for all metrics

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -323,7 +323,8 @@ async fn run() -> Result<(), Error> {
 }
 
 fn now_timestamp() -> i64 {
-    time::now_utc().to_timespec().sec
+    let timestamp = time::now_utc().to_timespec().sec;
+    timestamp - timestamp % 60
 }
 
 #[cfg(test)]
@@ -338,6 +339,7 @@ mod tests {
 
         assert_eq!("null", metric.node_name);
         assert!(metric.timestamp > 1736429031);
+        assert!(metric.timestamp % 60 == 0);
     }
 
     #[test]
@@ -360,6 +362,7 @@ mod tests {
         assert_eq!("node", metric.node_name);
         assert_eq!("", metric.pod_name);
         assert!(metric.timestamp > 1736429031);
+        assert!(metric.timestamp % 60 == 0);
     }
 
     #[test]
@@ -395,6 +398,7 @@ mod tests {
         assert_eq!("node", metric.node_name);
         assert_eq!("", metric.volume_name);
         assert!(metric.timestamp > 1736429031);
+        assert!(metric.timestamp % 60 == 0);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,8 @@ impl KubernetesMetrics {
             metric.set_volume_name(name.to_string());
         }
 
+        metric.set_timestamp(now_timestamp());
+
         if let Some(fs_available_bytes) = json["availableBytes"].as_i64() {
             metric.set_fs_available_bytes(fs_available_bytes);
         }
@@ -392,6 +394,7 @@ mod tests {
 
         assert_eq!("node", metric.node_name);
         assert_eq!("", metric.volume_name);
+        assert!(metric.timestamp > 1736429031);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -335,6 +335,7 @@ mod tests {
         let metric = KubernetesMetrics::from_node_json(json!([]));
 
         assert_eq!("null", metric.node_name);
+        assert!(metric.timestamp > 1736429031);
     }
 
     #[test]
@@ -356,6 +357,7 @@ mod tests {
 
         assert_eq!("node", metric.node_name);
         assert_eq!("", metric.pod_name);
+        assert!(metric.timestamp > 1736429031);
     }
 
     #[test]


### PR DESCRIPTION
Timestamps were set for Node and Pod metrics. This patch adds a test to make sure that actually happened. Also, timestamps were added before the addition of the volume metrics. This patch adds timestamps to volume metrics as well. 

@matsimitsu could you double-check this? Unless I'm missing something we already had timestamps set on most metrics, except for the volume ones. This version should set timestamps for all metrics all the time.

Closes #19. 