### PR TITLE
Use delta values for cumulative metrics

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,258 +17,267 @@ type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 impl KubernetesMetrics {
     pub fn from_node_json(json: serde_json::Value) -> Option<KubernetesMetrics> {
-        let mut metric = KubernetesMetrics::new();
+        match json["nodeName"].as_str() {
+            Some(node_name) => {
+                let mut metric = KubernetesMetrics::new();
 
-        if let Some(node_name) = json["nodeName"].as_str() {
-            metric.set_node_name(node_name.to_string());
+                metric.set_node_name(node_name.to_string());
+
+                metric.set_timestamp(now_timestamp());
+
+                if let Some(cpu_usage_nano_cores) = json["cpu"]["usageNanoCores"].as_i64() {
+                    metric.set_cpu_usage_nano_cores(cpu_usage_nano_cores);
+                }
+
+                if let Some(cpu_usage_core_nano_seconds) =
+                    json["cpu"]["usageCoreNanoSeconds"].as_i64()
+                {
+                    metric.set_cpu_usage_core_nano_seconds(cpu_usage_core_nano_seconds);
+                }
+
+                if let Some(memory_available_bytes) = json["memory"]["availableBytes"].as_i64() {
+                    metric.set_memory_available_bytes(memory_available_bytes);
+                }
+
+                if let Some(memory_usage_bytes) = json["memory"]["usageBytes"].as_i64() {
+                    metric.set_memory_usage_bytes(memory_usage_bytes);
+                }
+
+                if let Some(memory_working_set_bytes) = json["memory"]["workingSetBytes"].as_i64() {
+                    metric.set_memory_working_set_bytes(memory_working_set_bytes);
+                }
+
+                if let Some(memory_rss_bytes) = json["memory"]["rssBytes"].as_i64() {
+                    metric.set_memory_rss_bytes(memory_rss_bytes);
+                }
+
+                if let Some(memory_page_faults) = json["memory"]["pageFaults"].as_i64() {
+                    metric.set_memory_page_faults(memory_page_faults as i32);
+                }
+
+                if let Some(memory_major_page_faults) = json["memory"]["majorPageFaults"].as_i64() {
+                    metric.set_memory_major_page_faults(memory_major_page_faults as i32);
+                }
+
+                if let Some(network_rx_bytes) = json["network"]["rxBytes"].as_i64() {
+                    metric.set_network_rx_bytes(network_rx_bytes);
+                }
+
+                if let Some(network_rx_errors) = json["network"]["rxErrors"].as_i64() {
+                    metric.set_network_rx_errors(network_rx_errors as i32);
+                }
+
+                if let Some(network_tx_bytes) = json["network"]["txBytes"].as_i64() {
+                    metric.set_network_tx_bytes(network_tx_bytes);
+                }
+
+                if let Some(network_tx_errors) = json["network"]["txErrors"].as_i64() {
+                    metric.set_network_tx_errors(network_tx_errors as i32);
+                }
+
+                if let Some(fs_available_bytes) = json["fs"]["availableBytes"].as_i64() {
+                    metric.set_fs_available_bytes(fs_available_bytes);
+                }
+
+                if let Some(fs_capacity_bytes) = json["fs"]["capacityBytes"].as_i64() {
+                    metric.set_fs_capacity_bytes(fs_capacity_bytes);
+                }
+
+                if let Some(fs_used_bytes) = json["fs"]["usedBytes"].as_i64() {
+                    metric.set_fs_used_bytes(fs_used_bytes);
+                }
+
+                if let Some(fs_inodes_free) = json["fs"]["inodesFree"].as_i64() {
+                    metric.set_fs_inodes_free(fs_inodes_free);
+                }
+
+                if let Some(fs_inodes) = json["fs"]["inodes"].as_i64() {
+                    metric.set_fs_inodes(fs_inodes);
+                }
+
+                if let Some(fs_inodes_used) = json["fs"]["inodesUsed"].as_i64() {
+                    metric.set_fs_inodes_used(fs_inodes_used);
+                }
+
+                if let Some(rlimit_maxpid) = json["rlimit"]["maxpid"].as_i64() {
+                    metric.set_rlimit_maxpid(rlimit_maxpid as i32);
+                }
+
+                if let Some(rlimit_curproc) = json["rlimit"]["curproc"].as_i64() {
+                    metric.set_rlimit_curproc(rlimit_curproc as i32);
+                }
+
+                if let Some(swap_usage_bytes) = json["swap"]["swapUsageBytes"].as_i64() {
+                    metric.set_swap_usage_bytes(swap_usage_bytes);
+                }
+
+                if let Some(swap_available_bytes) = json["swap"]["swapAvailableBytes"].as_i64() {
+                    metric.set_swap_available_bytes(swap_available_bytes);
+                }
+
+                Some(metric)
+            }
+            _ => None,
         }
-
-        metric.set_timestamp(now_timestamp());
-
-        if let Some(cpu_usage_nano_cores) = json["cpu"]["usageNanoCores"].as_i64() {
-            metric.set_cpu_usage_nano_cores(cpu_usage_nano_cores);
-        }
-
-        if let Some(cpu_usage_core_nano_seconds) = json["cpu"]["usageCoreNanoSeconds"].as_i64() {
-            metric.set_cpu_usage_core_nano_seconds(cpu_usage_core_nano_seconds);
-        }
-
-        if let Some(memory_available_bytes) = json["memory"]["availableBytes"].as_i64() {
-            metric.set_memory_available_bytes(memory_available_bytes);
-        }
-
-        if let Some(memory_usage_bytes) = json["memory"]["usageBytes"].as_i64() {
-            metric.set_memory_usage_bytes(memory_usage_bytes);
-        }
-
-        if let Some(memory_working_set_bytes) = json["memory"]["workingSetBytes"].as_i64() {
-            metric.set_memory_working_set_bytes(memory_working_set_bytes);
-        }
-
-        if let Some(memory_rss_bytes) = json["memory"]["rssBytes"].as_i64() {
-            metric.set_memory_rss_bytes(memory_rss_bytes);
-        }
-
-        if let Some(memory_page_faults) = json["memory"]["pageFaults"].as_i64() {
-            metric.set_memory_page_faults(memory_page_faults as i32);
-        }
-
-        if let Some(memory_major_page_faults) = json["memory"]["majorPageFaults"].as_i64() {
-            metric.set_memory_major_page_faults(memory_major_page_faults as i32);
-        }
-
-        if let Some(network_rx_bytes) = json["network"]["rxBytes"].as_i64() {
-            metric.set_network_rx_bytes(network_rx_bytes);
-        }
-
-        if let Some(network_rx_errors) = json["network"]["rxErrors"].as_i64() {
-            metric.set_network_rx_errors(network_rx_errors as i32);
-        }
-
-        if let Some(network_tx_bytes) = json["network"]["txBytes"].as_i64() {
-            metric.set_network_tx_bytes(network_tx_bytes);
-        }
-
-        if let Some(network_tx_errors) = json["network"]["txErrors"].as_i64() {
-            metric.set_network_tx_errors(network_tx_errors as i32);
-        }
-
-        if let Some(fs_available_bytes) = json["fs"]["availableBytes"].as_i64() {
-            metric.set_fs_available_bytes(fs_available_bytes);
-        }
-
-        if let Some(fs_capacity_bytes) = json["fs"]["capacityBytes"].as_i64() {
-            metric.set_fs_capacity_bytes(fs_capacity_bytes);
-        }
-
-        if let Some(fs_used_bytes) = json["fs"]["usedBytes"].as_i64() {
-            metric.set_fs_used_bytes(fs_used_bytes);
-        }
-
-        if let Some(fs_inodes_free) = json["fs"]["inodesFree"].as_i64() {
-            metric.set_fs_inodes_free(fs_inodes_free);
-        }
-
-        if let Some(fs_inodes) = json["fs"]["inodes"].as_i64() {
-            metric.set_fs_inodes(fs_inodes);
-        }
-
-        if let Some(fs_inodes_used) = json["fs"]["inodesUsed"].as_i64() {
-            metric.set_fs_inodes_used(fs_inodes_used);
-        }
-
-        if let Some(rlimit_maxpid) = json["rlimit"]["maxpid"].as_i64() {
-            metric.set_rlimit_maxpid(rlimit_maxpid as i32);
-        }
-
-        if let Some(rlimit_curproc) = json["rlimit"]["curproc"].as_i64() {
-            metric.set_rlimit_curproc(rlimit_curproc as i32);
-        }
-
-        if let Some(swap_usage_bytes) = json["swap"]["swapUsageBytes"].as_i64() {
-            metric.set_swap_usage_bytes(swap_usage_bytes);
-        }
-
-        if let Some(swap_available_bytes) = json["swap"]["swapAvailableBytes"].as_i64() {
-            metric.set_swap_available_bytes(swap_available_bytes);
-        }
-
-        Some(metric)
     }
 
     pub fn from_pod_json(
         node_name: Option<&str>,
         json: serde_json::Value,
     ) -> Option<KubernetesMetrics> {
-        let mut metric = KubernetesMetrics::new();
+        match (node_name, json["podRef"]["name"].as_str()) {
+            (Some(node_name), Some(pod_name)) => {
+                let mut metric = KubernetesMetrics::new();
 
-        if let Some(name) = node_name {
-            metric.set_node_name(name.to_string());
+                metric.set_node_name(node_name.to_string());
+                metric.set_pod_name(pod_name.to_string());
+
+                if let Some(namespace) = json["podRef"]["namespace"].as_str() {
+                    metric.set_pod_namespace(namespace.to_string());
+                }
+
+                if let Some(uid) = json["podRef"]["uid"].as_str() {
+                    metric.set_pod_uuid(uid.to_string());
+                }
+
+                metric.set_timestamp(now_timestamp());
+
+                if let Some(cpu_usage_nano_cores) = json["cpu"]["usageNanoCores"].as_i64() {
+                    metric.set_cpu_usage_nano_cores(cpu_usage_nano_cores);
+                }
+
+                if let Some(cpu_usage_core_nano_seconds) =
+                    json["cpu"]["usageCoreNanoSeconds"].as_i64()
+                {
+                    metric.set_cpu_usage_core_nano_seconds(cpu_usage_core_nano_seconds);
+                }
+
+                if let Some(memory_usage_bytes) = json["memory"]["usageBytes"].as_i64() {
+                    metric.set_memory_usage_bytes(memory_usage_bytes);
+                }
+
+                if let Some(memory_working_set_bytes) = json["memory"]["workingSetBytes"].as_i64() {
+                    metric.set_memory_working_set_bytes(memory_working_set_bytes);
+                }
+
+                if let Some(memory_rss_bytes) = json["memory"]["rssBytes"].as_i64() {
+                    metric.set_memory_rss_bytes(memory_rss_bytes);
+                }
+
+                if let Some(memory_page_faults) = json["memory"]["pageFaults"].as_i64() {
+                    metric.set_memory_page_faults(memory_page_faults as i32);
+                }
+
+                if let Some(memory_major_page_faults) = json["memory"]["majorPageFaults"].as_i64() {
+                    metric.set_memory_major_page_faults(memory_major_page_faults as i32);
+                }
+
+                if let Some(network_rx_bytes) = json["network"]["rxBytes"].as_i64() {
+                    metric.set_network_rx_bytes(network_rx_bytes);
+                }
+
+                if let Some(network_rx_errors) = json["network"]["rxErrors"].as_i64() {
+                    metric.set_network_rx_errors(network_rx_errors as i32);
+                }
+
+                if let Some(network_tx_bytes) = json["network"]["txBytes"].as_i64() {
+                    metric.set_network_tx_bytes(network_tx_bytes);
+                }
+
+                if let Some(network_tx_errors) = json["network"]["txErrors"].as_i64() {
+                    metric.set_network_tx_errors(network_tx_errors as i32);
+                }
+
+                if let Some(ephemeral_storage_available_bytes) =
+                    json["ephemeral-storage"]["availableBytes"].as_i64()
+                {
+                    metric.set_ephemeral_storage_available_bytes(ephemeral_storage_available_bytes);
+                }
+
+                if let Some(ephemeral_storage_capacity_bytes) =
+                    json["ephemeral-storage"]["capacityBytes"].as_i64()
+                {
+                    metric.set_ephemeral_storage_capacity_bytes(ephemeral_storage_capacity_bytes);
+                }
+
+                if let Some(ephemeral_storage_used_bytes) =
+                    json["ephemeral-storage"]["usedBytes"].as_i64()
+                {
+                    metric.set_ephemeral_storage_used_bytes(ephemeral_storage_used_bytes);
+                }
+
+                if let Some(ephemeral_storage_inodes_free) =
+                    json["ephemeral-storage"]["inodesFree"].as_i64()
+                {
+                    metric.set_ephemeral_storage_inodes_free(ephemeral_storage_inodes_free);
+                }
+
+                if let Some(ephemeral_storage_inodes) = json["ephemeral-storage"]["inodes"].as_i64()
+                {
+                    metric.set_ephemeral_storage_inodes(ephemeral_storage_inodes);
+                }
+
+                if let Some(ephemeral_storage_inodes_used) =
+                    json["ephemeral-storage"]["inodesUsed"].as_i64()
+                {
+                    metric.set_ephemeral_storage_inodes_used(ephemeral_storage_inodes_used);
+                }
+
+                if let Some(process_count) = json["process_stats"]["process_count"].as_i64() {
+                    metric.set_process_count(process_count as i32);
+                }
+
+                if let Some(swap_usage_bytes) = json["swap"]["swapUsageBytes"].as_i64() {
+                    metric.set_swap_usage_bytes(swap_usage_bytes);
+                }
+
+                Some(metric)
+            }
+            _ => None,
         }
-
-        if let Some(name) = json["podRef"]["name"].as_str() {
-            metric.set_pod_name(name.to_string());
-        }
-
-        if let Some(namespace) = json["podRef"]["namespace"].as_str() {
-            metric.set_pod_namespace(namespace.to_string());
-        }
-
-        if let Some(uid) = json["podRef"]["uid"].as_str() {
-            metric.set_pod_uuid(uid.to_string());
-        }
-
-        metric.set_timestamp(now_timestamp());
-
-        if let Some(cpu_usage_nano_cores) = json["cpu"]["usageNanoCores"].as_i64() {
-            metric.set_cpu_usage_nano_cores(cpu_usage_nano_cores);
-        }
-
-        if let Some(cpu_usage_core_nano_seconds) = json["cpu"]["usageCoreNanoSeconds"].as_i64() {
-            metric.set_cpu_usage_core_nano_seconds(cpu_usage_core_nano_seconds);
-        }
-
-        if let Some(memory_usage_bytes) = json["memory"]["usageBytes"].as_i64() {
-            metric.set_memory_usage_bytes(memory_usage_bytes);
-        }
-
-        if let Some(memory_working_set_bytes) = json["memory"]["workingSetBytes"].as_i64() {
-            metric.set_memory_working_set_bytes(memory_working_set_bytes);
-        }
-
-        if let Some(memory_rss_bytes) = json["memory"]["rssBytes"].as_i64() {
-            metric.set_memory_rss_bytes(memory_rss_bytes);
-        }
-
-        if let Some(memory_page_faults) = json["memory"]["pageFaults"].as_i64() {
-            metric.set_memory_page_faults(memory_page_faults as i32);
-        }
-
-        if let Some(memory_major_page_faults) = json["memory"]["majorPageFaults"].as_i64() {
-            metric.set_memory_major_page_faults(memory_major_page_faults as i32);
-        }
-
-        if let Some(network_rx_bytes) = json["network"]["rxBytes"].as_i64() {
-            metric.set_network_rx_bytes(network_rx_bytes);
-        }
-
-        if let Some(network_rx_errors) = json["network"]["rxErrors"].as_i64() {
-            metric.set_network_rx_errors(network_rx_errors as i32);
-        }
-
-        if let Some(network_tx_bytes) = json["network"]["txBytes"].as_i64() {
-            metric.set_network_tx_bytes(network_tx_bytes);
-        }
-
-        if let Some(network_tx_errors) = json["network"]["txErrors"].as_i64() {
-            metric.set_network_tx_errors(network_tx_errors as i32);
-        }
-
-        if let Some(ephemeral_storage_available_bytes) =
-            json["ephemeral-storage"]["availableBytes"].as_i64()
-        {
-            metric.set_ephemeral_storage_available_bytes(ephemeral_storage_available_bytes);
-        }
-
-        if let Some(ephemeral_storage_capacity_bytes) =
-            json["ephemeral-storage"]["capacityBytes"].as_i64()
-        {
-            metric.set_ephemeral_storage_capacity_bytes(ephemeral_storage_capacity_bytes);
-        }
-
-        if let Some(ephemeral_storage_used_bytes) = json["ephemeral-storage"]["usedBytes"].as_i64()
-        {
-            metric.set_ephemeral_storage_used_bytes(ephemeral_storage_used_bytes);
-        }
-
-        if let Some(ephemeral_storage_inodes_free) =
-            json["ephemeral-storage"]["inodesFree"].as_i64()
-        {
-            metric.set_ephemeral_storage_inodes_free(ephemeral_storage_inodes_free);
-        }
-
-        if let Some(ephemeral_storage_inodes) = json["ephemeral-storage"]["inodes"].as_i64() {
-            metric.set_ephemeral_storage_inodes(ephemeral_storage_inodes);
-        }
-
-        if let Some(ephemeral_storage_inodes_used) =
-            json["ephemeral-storage"]["inodesUsed"].as_i64()
-        {
-            metric.set_ephemeral_storage_inodes_used(ephemeral_storage_inodes_used);
-        }
-
-        if let Some(process_count) = json["process_stats"]["process_count"].as_i64() {
-            metric.set_process_count(process_count as i32);
-        }
-
-        if let Some(swap_usage_bytes) = json["swap"]["swapUsageBytes"].as_i64() {
-            metric.set_swap_usage_bytes(swap_usage_bytes);
-        }
-
-        Some(metric)
     }
 
     pub fn from_volume_json(
         node_name: Option<&str>,
         json: serde_json::Value,
     ) -> Option<KubernetesMetrics> {
-        let mut metric = KubernetesMetrics::new();
+        match (node_name, json["name"].as_str()) {
+            (Some(node_name), Some(volume_name)) => {
+                let mut metric = KubernetesMetrics::new();
 
-        if let Some(name) = node_name {
-            metric.set_node_name(name.to_string());
+                metric.set_node_name(node_name.to_string());
+                metric.set_volume_name(volume_name.to_string());
+
+                metric.set_timestamp(now_timestamp());
+
+                if let Some(fs_available_bytes) = json["availableBytes"].as_i64() {
+                    metric.set_fs_available_bytes(fs_available_bytes);
+                }
+
+                if let Some(fs_capacity_bytes) = json["capacityBytes"].as_i64() {
+                    metric.set_fs_capacity_bytes(fs_capacity_bytes);
+                }
+
+                if let Some(fs_used_bytes) = json["usedBytes"].as_i64() {
+                    metric.set_fs_used_bytes(fs_used_bytes);
+                }
+
+                if let Some(fs_inodes_free) = json["inodesFree"].as_i64() {
+                    metric.set_fs_inodes_free(fs_inodes_free);
+                }
+
+                if let Some(fs_inodes) = json["inodes"].as_i64() {
+                    metric.set_fs_inodes(fs_inodes);
+                }
+
+                if let Some(fs_inodes_used) = json["inodesUsed"].as_i64() {
+                    metric.set_fs_inodes_used(fs_inodes_used);
+                }
+
+                Some(metric)
+            }
+            _ => None,
         }
-
-        if let Some(name) = json["name"].as_str() {
-            metric.set_volume_name(name.to_string());
-        }
-
-        metric.set_timestamp(now_timestamp());
-
-        if let Some(fs_available_bytes) = json["availableBytes"].as_i64() {
-            metric.set_fs_available_bytes(fs_available_bytes);
-        }
-
-        if let Some(fs_capacity_bytes) = json["capacityBytes"].as_i64() {
-            metric.set_fs_capacity_bytes(fs_capacity_bytes);
-        }
-
-        if let Some(fs_used_bytes) = json["usedBytes"].as_i64() {
-            metric.set_fs_used_bytes(fs_used_bytes);
-        }
-
-        if let Some(fs_inodes_free) = json["inodesFree"].as_i64() {
-            metric.set_fs_inodes_free(fs_inodes_free);
-        }
-
-        if let Some(fs_inodes) = json["inodes"].as_i64() {
-            metric.set_fs_inodes(fs_inodes);
-        }
-
-        if let Some(fs_inodes_used) = json["inodesUsed"].as_i64() {
-            metric.set_fs_inodes_used(fs_inodes_used);
-        }
-
-        Some(metric)
     }
 }
 
@@ -381,11 +390,7 @@ mod tests {
 
     #[test]
     fn extract_node_metrics_with_empty_results() {
-        let metric = KubernetesMetrics::from_node_json(json!([])).unwrap();
-
-        assert_eq!("", metric.node_name);
-        assert!(metric.timestamp > 1736429031);
-        assert!(metric.timestamp % 60 == 0);
+        assert_eq!(None, KubernetesMetrics::from_node_json(json!([])));
     }
 
     #[test]
@@ -393,6 +398,9 @@ mod tests {
         let metric = KubernetesMetrics::from_node_json(json()["node"].clone()).unwrap();
 
         assert_eq!("pool-k1f1it7zb-ekz6u", metric.node_name);
+
+        assert!(metric.timestamp > 1736429031);
+        assert!(metric.timestamp % 60 == 0);
 
         assert_eq!(44128133, metric.cpu_usage_nano_cores);
         assert_eq!(83361299610000, metric.cpu_usage_core_nano_seconds);
@@ -442,12 +450,7 @@ mod tests {
 
     #[test]
     fn extract_pod_metrics_with_empty_results() {
-        let metric = KubernetesMetrics::from_pod_json(None, json!([])).unwrap();
-
-        assert_eq!("", metric.node_name);
-        assert_eq!("", metric.pod_name);
-        assert!(metric.timestamp > 1736429031);
-        assert!(metric.timestamp % 60 == 0);
+        assert_eq!(None, KubernetesMetrics::from_pod_json(None, json!([])));
     }
 
     #[test]
@@ -459,6 +462,9 @@ mod tests {
         assert_eq!("konnectivity-agent-8qf4d", metric.pod_name);
         assert_eq!("kube-system", metric.pod_namespace);
         assert_eq!("eba341db-5f3c-4cbf-9f2d-1ca9e926c7e4", metric.pod_uuid);
+
+        assert!(metric.timestamp > 1736429031);
+        assert!(metric.timestamp % 60 == 0);
 
         assert_eq!(409594, metric.cpu_usage_nano_cores);
         assert_eq!(631022780000, metric.cpu_usage_core_nano_seconds);
@@ -488,12 +494,7 @@ mod tests {
 
     #[test]
     fn extract_volume_metrics_with_empty_results() {
-        let metric = KubernetesMetrics::from_volume_json(None, json!([])).unwrap();
-
-        assert_eq!("", metric.node_name);
-        assert_eq!("", metric.volume_name);
-        assert!(metric.timestamp > 1736429031);
-        assert!(metric.timestamp % 60 == 0);
+        assert_eq!(None, KubernetesMetrics::from_volume_json(None, json!([])));
     }
 
     #[test]
@@ -515,6 +516,10 @@ mod tests {
 
         assert_eq!("node", metric.node_name);
         assert_eq!("kube-api-access-qz4b4", metric.volume_name);
+
+        assert!(metric.timestamp > 1736429031);
+        assert!(metric.timestamp % 60 == 0);
+
         assert_eq!(8318251008, metric.fs_available_bytes);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,6 +279,20 @@ impl KubernetesMetrics {
             _ => None,
         }
     }
+
+    pub fn delta(&self, previous: KubernetesMetrics) -> KubernetesMetrics {
+        let mut new = self.clone();
+
+        new.set_network_rx_bytes(new.get_network_rx_bytes() - previous.get_network_rx_bytes());
+
+        new.set_network_rx_errors(new.get_network_rx_errors() - previous.get_network_rx_errors());
+
+        new.set_network_tx_bytes(new.get_network_tx_bytes() - previous.get_network_tx_bytes());
+
+        new.set_network_tx_errors(new.get_network_tx_errors() - previous.get_network_tx_errors());
+
+        new
+    }
 }
 
 #[tokio::main]
@@ -521,5 +535,19 @@ mod tests {
         assert!(metric.timestamp % 60 == 0);
 
         assert_eq!(8318251008, metric.fs_available_bytes);
+    }
+
+    #[test]
+    fn delta_subtracts_network_data() {
+        let metric = KubernetesMetrics::from_node_json(json()["node"].clone())
+            .clone()
+            .unwrap();
+
+        let new = metric.delta(metric.clone());
+
+        assert_eq!(0, new.network_rx_bytes);
+        assert_eq!(0, new.network_rx_errors);
+        assert_eq!(0, new.network_tx_bytes);
+        assert_eq!(0, new.network_tx_errors);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,6 +361,12 @@ mod tests {
     use std::assert_eq;
     use std::fs::File;
 
+    fn json() -> serde_json::Value {
+        let file =
+            File::open("test/fixtures/digitalocean.json").expect("Could not open example file");
+        serde_json::from_reader(file).expect("Could not parse example file")
+    }
+
     #[test]
     fn extract_node_metrics_with_empty_results() {
         let metric = KubernetesMetrics::from_node_json(json!([]));
@@ -372,11 +378,7 @@ mod tests {
 
     #[test]
     fn extract_node_metrics_with_results() {
-        let file = File::open("test/fixtures/digitalocean.json").expect("Could not open example file");
-        let json: serde_json::Value =
-            serde_json::from_reader(file).expect("Could not parse example file");
-
-        let metric = KubernetesMetrics::from_node_json(json["node"].clone());
+        let metric = KubernetesMetrics::from_node_json(json()["node"].clone());
 
         assert_eq!("pool-k1f1it7zb-ekz6u", metric.node_name);
 
@@ -437,11 +439,7 @@ mod tests {
 
     #[test]
     fn extract_pod_metrics_with_results() {
-        let file = File::open("test/fixtures/digitalocean.json").expect("Could not open example file");
-        let json: serde_json::Value =
-            serde_json::from_reader(file).expect("Could not parse example file");
-
-        let metric = KubernetesMetrics::from_pod_json(Some("node"), json["pods"][0].clone());
+        let metric = KubernetesMetrics::from_pod_json(Some("node"), json()["pods"][0].clone());
 
         assert_eq!("node", metric.node_name);
         assert_eq!("konnectivity-agent-8qf4d", metric.pod_name);


### PR DESCRIPTION
Instead of sending the network metrics as we get them, subtract the previous minute's value to get the minutely value. Currently, this only happens for the network metrics, but more metrics can be added if needed.