### PR TITLE
Add memory_usage as a percentage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,9 +66,10 @@ impl KubernetesMetrics {
                     let memory_capacity_bytes = memory_available_bytes + memory_usage_bytes;
 
                     metric.set_memory_usage(
-                        (memory_usage_bytes / memory_capacity_bytes * 100.0)
-                            .clamp(0.0, 100.0)
-                            .round() as i32,
+                        Self::percentage_from(
+                            memory_usage_bytes,
+                            memory_capacity_bytes
+                        )
                     );
                 }
 
@@ -105,9 +106,10 @@ impl KubernetesMetrics {
                     json["fs"]["usedBytes"].as_f64(),
                 ) {
                     metric.set_disk_usage(
-                        (fs_used_bytes / fs_capacity_bytes * 100.0)
-                            .clamp(0.0, 100.0)
-                            .round() as i32,
+                        Self::percentage_from(
+                            fs_used_bytes,
+                            fs_capacity_bytes
+                        )
                     );
                 }
 
@@ -339,6 +341,10 @@ impl KubernetesMetrics {
             Some(previous) => Some(self.delta(previous.clone())),
             _ => None,
         }
+    }
+
+    fn percentage_from(value: f64, total: f64) -> i32 {
+        (value / total * 100.0).clamp(0.0, 100.0).round() as i32
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,16 +59,15 @@ impl KubernetesMetrics {
                     metric.set_memory_major_page_faults(memory_major_page_faults as i32);
                 }
 
-                if let (Some(memory_available_bytes), Some(memory_usage_bytes)) = (
+                if let (Some(memory_available_bytes), Some(memory_usage_bytes), Some(memory_rss_bytes)) = (
                     json["memory"]["availableBytes"].as_f64(),
                     json["memory"]["usageBytes"].as_f64(),
+                    json["memory"]["rssBytes"].as_f64(),
                 ) {
-                    let memory_capacity_bytes = memory_available_bytes + memory_usage_bytes;
-
                     metric.set_memory_usage(
                         Self::percentage_from(
-                            memory_usage_bytes,
-                            memory_capacity_bytes
+                            memory_usage_bytes - memory_rss_bytes,
+                            memory_usage_bytes + memory_available_bytes - memory_rss_bytes
                         )
                     );
                 }
@@ -498,7 +497,7 @@ mod tests {
         assert_eq!(97153339, metric.memory_page_faults);
         assert_eq!(3780, metric.memory_major_page_faults);
 
-        assert_eq!(60, metric.memory_usage);
+        assert_eq!(52, metric.memory_usage);
 
         assert_eq!(6011987255, metric.network_rx_bytes);
         assert_eq!(42, metric.network_rx_errors);


### PR DESCRIPTION
This patch adds memory_usage, a combined field that's set for nodes by combining the memory_usage_bytes, memory_available_bytes and memory_rss_bytes fields. 

Closes https://github.com/appsignal/appsignal-kubernetes/issues/27

[skip changeset]