### PR TITLE
Print configuration on startup to aid in debugging

### DIFF
--- a/.changesets/print-configuration-on-startup-to-aid-in-debugging.md
+++ b/.changesets/print-configuration-on-startup-to-aid-in-debugging.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Print configuration on startup to aid in debugging

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -23,6 +23,8 @@ spec:
             secretKeyRef:
               name: appsignal
               key: api-key
+        - name: RUST_LOG
+          value: info
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ extern crate time;
 use http::Request;
 use k8s_openapi::api::core::v1::Node;
 use kube::{api::ListParams, Api, ResourceExt};
-use log::{debug, trace, warn};
+use log::{info, trace, warn};
 use protobuf::Message;
 use reqwest::{Client, Url};
 use std::env;
@@ -490,7 +490,7 @@ async fn run(previous: Vec<KubernetesMetrics>) -> Result<Vec<KubernetesMetrics>,
             .send()
             .await?;
 
-        debug!("Metric sent: {:?}", appsignal_response);
+        info!("Metric sent: {:?}", appsignal_response);
     }
 
     Ok(metrics)


### PR DESCRIPTION
This patch adds debug logging when the integration starts, and makes sure the log level is at least set to info.