### PR TITLE
Build each target on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,4 +28,27 @@ jobs:
           password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
       - run: cargo clippy --verbose --tests --all-targets --all-features -- -D warnings
       - run: cargo fmt --check --verbose
-      - run: rake test
+      - run: cargo test --verbose
+
+  build_release:
+    name: "Build every target"
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-musl
+          - target: x86_64-unknown-linux-musl
+    steps:
+      # Linux targets will cross compile on Docker images used by cross
+      - name: "Login to Docker Hub"
+        uses: docker/login-action@v3
+        with:
+          username: ${{secrets.CI_DOCKERHUB_USERNAME}}
+          password: ${{secrets.CI_DOCKERHUB_TOKEN}}
+
+      - name: "Checkout project"
+        uses: actions/checkout@v4
+
+      - name: "Build target for ${{matrix.target}}"
+        run: "rake build:target:${{matrix.target}}"

--- a/Rakefile
+++ b/Rakefile
@@ -127,13 +127,6 @@ task :publish => "build:target:all" do
   puts "Published images '#{tag}' and 'latest'"
 end
 
-desc "Run Rust unit tests"
-task :test => "build:prepare" do
-  TARGETS.each do |target_triple, config|
-    Command.run("cross test --release --target #{target_triple}")
-  end
-end
-
 desc "Regenerate the protocol"
 task :protocol do
   `mkdir -p protocol`


### PR DESCRIPTION
To make sure any changes don't break the release builds, let's build them in the CI.

That way, we don't find out the build is broken when we try to run the release workflow.

I've reverted the `cargo test` commands to just run `cargo test` on the Ubuntu runner for now as we do in our other projects too.

We may want to revisit this, but let's first add the release build test steps.

[skip changeset]