### PR TITLE
Add release step to the publish workflow

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -56,6 +56,15 @@ jobs:
             --message "Update version number and CHANGELOG.md."
           git tag "v${{steps.version.outputs.RELEASE_VERSION}}"
 
+      - name: "Create a release on the repository"
+        run: |
+          gh release create ${{steps.version.outputs.RELEASE_VERSION}} \
+            --title "Release ${{steps.version.outputs.RELEASE_VERSION}}" \
+            --verify-tag \
+            --notes-from-tag
+        env:
+          GH_TOKEN: ${{github.token}}
+
       - name: "Login to Docker Hub"
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
This patch adds a call to gh release to create a new release after committing the changes to the repository.

[skip changeset]