### PR TITLE
Fix pod permisions configuration

### DIFF
--- a/.changesets/fix-pod-permissions.md
+++ b/.changesets/fix-pod-permissions.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix permissions for accessing pod metrics.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "appsignal-kubernetes"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "appsignal-transmitter",
  "env_logger",

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -40,6 +40,7 @@ rules:
     resources:
       - nodes
       - "nodes/proxy"
+      - pods
     verbs:
       - get
       - list


### PR DESCRIPTION
Update the `deployment.yaml` file to also request access to pods so we can fetch the pods list.

Fixes this error:

```
Failed to extract metrics: ApiError: pods is forbidden: User "system:serviceaccount:default:appsignal-kubernetes-service-account" cannot list resource "pods" in API group "" at the cluster scope: Forbidden (ErrorResponse { status: "Failure", message: "pods is forbidden: User \"system:serviceaccount:default:appsignal-kubernetes-service-account\" cannot list resource \"pods\" in API group \"\" at the cluster scope", reason: "Forbidden", code: 403 })
```