### PR TITLE
Commit all release file changes

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -48,15 +48,6 @@ jobs:
           export RELEASE_VERSION="$(script/read_version)"
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: "Git commit changes"
-        run: |
-          git add .
-          git commit \
-            --gpg-sign \
-            --message "Release version ${{steps.version.outputs.RELEASE_VERSION}}" \
-            --message "Update version number and CHANGELOG.md."
-          git tag "v${{steps.version.outputs.RELEASE_VERSION}}"
-
       - name: "Login to Docker Hub"
         uses: docker/login-action@v3
         with:
@@ -65,6 +56,15 @@ jobs:
 
       - name: "Build and publish to Docker Hub"
         run: rake publish
+
+      - name: "Git commit changes"
+        run: |
+          git add .
+          git commit \
+            --gpg-sign \
+            --message "Release version ${{steps.version.outputs.RELEASE_VERSION}}" \
+            --message "Update version number and CHANGELOG.md."
+          git tag "v${{steps.version.outputs.RELEASE_VERSION}}"
 
       - name: "Push release to repository"
         run: git push origin ${{github.ref_name}} "v${{steps.version.outputs.RELEASE_VERSION}}"


### PR DESCRIPTION
I noticed that after a release the Cargo.lock would be modified. This ensures it commits the updated version.

[skip changeset]
[skip review]