### PR TITLE
Implement an actual Helm chart

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -40,6 +40,11 @@ jobs:
           echo "$(git config --get user.email) namespaces=\"git\" $(cat $PUBLISH_GIT_SIGN_KEY_PATH.pub)" >> ~/.ssh/allowed_signers
           git config --global user.signingkey "$PUBLISH_GIT_SIGN_KEY_PATH"
 
+      - name: "Install Helm"
+        uses: azure/setup-helm@v4
+        with:
+          version: 'v3.14.0'
+
       - name: "Create version"
         id: version
         run: |

--- a/README.md
+++ b/README.md
@@ -1,27 +1,33 @@
 # AppSignal for Kubernetes
 
-Extracts Kubenetes Cluster Metrics.
+AppSignal for Kubernetes is an agent that collects and sends metrics about your Kubernetes cluster to your AppSignal account.
 
 ## Installation
 
-In a Kubernetes cluster, set up your AppSignal API key (find your _App-specific_ API key in [App settings](https://appsignal.com/redirect-to/app?to=info)) by creating a secret:
+First, set up your AppSignal API key (find your _App-specific_ API key in [App settings](https://appsignal.com/redirect-to/app?to=info)) by creating a secret:
 
-    kubectl create secret generic appsignal --from-literal=api-key=00000000-0000-0000-0000-000000000000
+    kubectl create secret generic appsignal --from-literal=api-key=00000000-0000-0000-0000-000000000000 --namespace appsignal
 
-Then, add the AppSignal deployment to your cluster:
+### Using kubectl
+
+Install AppSignal for Kubernetes by applying the deployment manifest:
 
     kubectl apply -f https://raw.githubusercontent.com/appsignal/appsignal-kubernetes/main/deployment.yaml
 
-Alternatively, install AppSignal through its Helm chart:
+This will create the `appsignal` namespace and deploy the AppSignal for Kubernetes agent in that namespace.
+
+### Using Helm
+
+Add the AppSignal Helm repository and install the chart:
 
     helm repo add appsignal-kubernetes https://appsignal.github.io/appsignal-kubernetes
-    helm install appsignal-kubernetes/appsignal-kubernetes --generate-name
-
-AppSignal for Kubernetes will start sending Kubernetes automatically.
+    helm install appsignal-kubernetes appsignal-kubernetes/appsignal-kubernetes --create-namespace --namespace appsignal
 
 ## Cluster Metrics
 
-After installing AppSignal for Kubernetes into a cluster, AppSignal's Host Metrics are automatically replaced with Cluster Metrics to display cluster metrics.
+AppSignal for Kubernetes will start sending Kubernetes metrics automatically.
+
+After installing AppSignal for Kubernetes, AppSignal's Host Metrics are automatically replaced with Cluster Metrics to display cluster metrics.
 
 ## Development
 

--- a/charts/appsignal-kubernetes/Chart.yaml
+++ b/charts/appsignal-kubernetes/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: appsignal-kubernetes
-description: A Helm chart for Kubernetes
+description: A Helm chart for AppSignal Kubernetes monitoring
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -16,3 +16,8 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.1.2
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: "1.1.2"

--- a/charts/appsignal-kubernetes/templates/deployment.yaml
+++ b/charts/appsignal-kubernetes/templates/deployment.yaml
@@ -1,40 +1,116 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "appsignal-kubernetes.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "appsignal-kubernetes.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "appsignal-kubernetes.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "appsignal-kubernetes.labels" -}}
+helm.sh/chart: {{ include "appsignal-kubernetes.chart" . }}
+{{ include "appsignal-kubernetes.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "appsignal-kubernetes.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "appsignal-kubernetes.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "appsignal-kubernetes.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "appsignal-kubernetes.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: appsignal-kubernetes
+  name: {{ include "appsignal-kubernetes.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "appsignal-kubernetes.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: appsignal-kubernetes
+      {{- include "appsignal-kubernetes.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: appsignal-kubernetes
+        {{- include "appsignal-kubernetes.selectorLabels" . | nindent 8 }}
     spec:
-      serviceAccountName: appsignal-kubernetes-service-account
+      serviceAccountName: {{ include "appsignal-kubernetes.serviceAccountName" . }}
       containers:
-      - name: appsignal-kubernetes
-        image: appsignal/appsignal-kubernetes:1.1.2
-        imagePullPolicy: IfNotPresent
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: APPSIGNAL_API_KEY
           valueFrom:
             secretKeyRef:
-              name: appsignal
-              key: api-key
+              name: {{ .Values.appsignal.secretName }}
+              key: {{ .Values.appsignal.secretKey }}
         - name: RUST_LOG
-          value: info
+          value: {{ .Values.logLevel }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
 ---
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: appsignal-kubernetes-service-account
+  name: {{ include "appsignal-kubernetes.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "appsignal-kubernetes.labels" . | nindent 4 }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: appsignal-kubernetes-role
+  name: {{ include "appsignal-kubernetes.fullname" . }}
+  labels:
+    {{- include "appsignal-kubernetes.labels" . | nindent 4 }}
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
@@ -45,12 +121,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: appsignal-kubernetes-cluster-role-binding
+  name: {{ include "appsignal-kubernetes.fullname" . }}
+  labels:
+    {{- include "appsignal-kubernetes.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: appsignal-kubernetes-role
+  name: {{ include "appsignal-kubernetes.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: appsignal-kubernetes-service-account
-    namespace: default
+    name: {{ include "appsignal-kubernetes.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/appsignal-kubernetes/templates/namespace.yaml
+++ b/charts/appsignal-kubernetes/templates/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  labels:
+    {{- include "appsignal-kubernetes.labels" . | nindent 4 }}

--- a/charts/appsignal-kubernetes/values.yaml
+++ b/charts/appsignal-kubernetes/values.yaml
@@ -5,59 +5,31 @@
 replicaCount: 1
 
 image:
-  repository: nginx
+  repository: appsignal/appsignal-kubernetes
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "1.1.2"
 
-imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # Automatically mount a ServiceAccount's API credentials?
   automount: true
-  # Annotations to add to the service account
-  annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podAnnotations: {}
-podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+# AppSignal configuration
+appsignal:
+  # Secret name containing the API key
+  secretName: "appsignal"
+  # Secret key containing the API key
+  secretKey: "api-key"
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
-
-service:
-  type: ClusterIP
-  port: 80
-
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+# Log level for the application
+logLevel: "info"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -71,37 +43,3 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-livenessProbe:
-  httpGet:
-    path: /
-    port: http
-readinessProbe:
-  httpGet:
-    path: /
-    port: http
-
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
-
-# Additional volumes on the output Deployment definition.
-volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
-
-# Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,21 +1,96 @@
+---
+# Source: appsignal-kubernetes/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: appsignal
+  labels:
+    helm.sh/chart: appsignal-kubernetes-1.1.2
+    app.kubernetes.io/name: appsignal-kubernetes
+    app.kubernetes.io/instance: appsignal-kubernetes
+    app.kubernetes.io/version: "1.1.2"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: appsignal-kubernetes/templates/deployment.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: appsignal-kubernetes
+  namespace: appsignal
+  labels:
+    helm.sh/chart: appsignal-kubernetes-1.1.2
+    app.kubernetes.io/name: appsignal-kubernetes
+    app.kubernetes.io/instance: appsignal-kubernetes
+    app.kubernetes.io/version: "1.1.2"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: appsignal-kubernetes/templates/deployment.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: appsignal-kubernetes
+  labels:
+    helm.sh/chart: appsignal-kubernetes-1.1.2
+    app.kubernetes.io/name: appsignal-kubernetes
+    app.kubernetes.io/instance: appsignal-kubernetes
+    app.kubernetes.io/version: "1.1.2"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs:
+      - get
+      - list
+---
+# Source: appsignal-kubernetes/templates/deployment.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: appsignal-kubernetes
+  labels:
+    helm.sh/chart: appsignal-kubernetes-1.1.2
+    app.kubernetes.io/name: appsignal-kubernetes
+    app.kubernetes.io/instance: appsignal-kubernetes
+    app.kubernetes.io/version: "1.1.2"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appsignal-kubernetes
+subjects:
+  - kind: ServiceAccount
+    name: appsignal-kubernetes
+    namespace: appsignal
+---
+# Source: appsignal-kubernetes/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: appsignal-kubernetes
+  namespace: appsignal
+  labels:
+    helm.sh/chart: appsignal-kubernetes-1.1.2
+    app.kubernetes.io/name: appsignal-kubernetes
+    app.kubernetes.io/instance: appsignal-kubernetes
+    app.kubernetes.io/version: "1.1.2"
+    app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: appsignal-kubernetes
+      app.kubernetes.io/name: appsignal-kubernetes
+      app.kubernetes.io/instance: appsignal-kubernetes
   template:
     metadata:
       labels:
-        app: appsignal-kubernetes
+        app.kubernetes.io/name: appsignal-kubernetes
+        app.kubernetes.io/instance: appsignal-kubernetes
     spec:
-      serviceAccountName: appsignal-kubernetes-service-account
+      serviceAccountName: appsignal-kubernetes
       containers:
       - name: appsignal-kubernetes
-        image: appsignal/appsignal-kubernetes:1.1.2
+        image: "appsignal/appsignal-kubernetes:1.1.2"
         imagePullPolicy: IfNotPresent
         env:
         - name: APPSIGNAL_API_KEY
@@ -25,32 +100,5 @@ spec:
               key: api-key
         - name: RUST_LOG
           value: info
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: appsignal-kubernetes-service-account
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: appsignal-kubernetes-role
-rules:
-  - apiGroups: ["*"]
-    resources: ["*"]
-    verbs:
-      - get
-      - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: appsignal-kubernetes-cluster-role-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: appsignal-kubernetes-role
-subjects:
-  - kind: ServiceAccount
-    name: appsignal-kubernetes-service-account
-    namespace: default
+        resources:
+            {}

--- a/script/write_version
+++ b/script/write_version
@@ -8,10 +8,9 @@ File.write(
   File.read("Cargo.toml").sub(/^version = ".*"$/, %(version = "#{VERSION}"))
 )
 File.write(
-  "deployment.yaml",
-  File.read("deployment.yaml").sub(/image: appsignal\/appsignal-kubernetes:.*$/, "image: appsignal/appsignal-kubernetes:#{VERSION}")
-)
-system("rake update_helm_templates")
-File.write(
   "charts/appsignal-kubernetes/Chart.yaml",
   File.read("charts/appsignal-kubernetes/Chart.yaml").sub(/^version: .*$/, %(version: #{VERSION})))
+File.write(
+  "charts/appsignal-kubernetes/Chart.yaml",
+  File.read("charts/appsignal-kubernetes/Chart.yaml").sub(/^appVersion: .*$/, %(appVersion: "#{VERSION}")))
+system("rake generate_deployment")


### PR DESCRIPTION
Our existing Helm chart is just a copy and paste of the existing `deployment.yaml` for `kubectl`, with some unrelated broken files alongside it.

Replace this with templates that actually interpolate the values in the chart. Rather than having the release process copy-paste the `deployment.yaml` from the root into the chart, do the opposite: use Helm's template as the source of truth to generate `deployment.yaml` from.

Fixes #59.

### To do

- [ ] Update docs for Helm (see `README.md` changes)