### PR TITLE
Do not describe deployment as managed by Helm

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -139,6 +139,7 @@ task :generate_deployment do
   
   # Create a temporary values file with only the overrides needed for standalone deployment
   values_override = <<~VALUES
+    managed: false
     image:
       tag: "#{current_version}"
   VALUES

--- a/charts/appsignal-kubernetes/templates/deployment.yaml
+++ b/charts/appsignal-kubernetes/templates/deployment.yaml
@@ -39,7 +39,9 @@ helm.sh/chart: {{ include "appsignal-kubernetes.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
+{{- if .Values.managed }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/appsignal-kubernetes/values.yaml
+++ b/charts/appsignal-kubernetes/values.yaml
@@ -31,6 +31,9 @@ appsignal:
 # Log level for the application
 logLevel: "info"
 
+# Whether resources should be described as managed by Helm
+managed: true
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/name: appsignal-kubernetes
     app.kubernetes.io/instance: appsignal-kubernetes
     app.kubernetes.io/version: "1.2.0"
-    app.kubernetes.io/managed-by: Helm
 ---
 # Source: appsignal-kubernetes/templates/deployment.yaml
 apiVersion: v1
@@ -22,7 +21,6 @@ metadata:
     app.kubernetes.io/name: appsignal-kubernetes
     app.kubernetes.io/instance: appsignal-kubernetes
     app.kubernetes.io/version: "1.2.0"
-    app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
 # Source: appsignal-kubernetes/templates/deployment.yaml
@@ -35,7 +33,6 @@ metadata:
     app.kubernetes.io/name: appsignal-kubernetes
     app.kubernetes.io/instance: appsignal-kubernetes
     app.kubernetes.io/version: "1.2.0"
-    app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
@@ -53,7 +50,6 @@ metadata:
     app.kubernetes.io/name: appsignal-kubernetes
     app.kubernetes.io/instance: appsignal-kubernetes
     app.kubernetes.io/version: "1.2.0"
-    app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -74,7 +70,6 @@ metadata:
     app.kubernetes.io/name: appsignal-kubernetes
     app.kubernetes.io/instance: appsignal-kubernetes
     app.kubernetes.io/version: "1.2.0"
-    app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Do not describe the `kubectl`-oriented `deployment.yaml` file as "managed by Helm" in the labels.