### PR TITLE
Fix namespace creation in Helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AppSignal for Kubernetes
 
-AppSignal for Kubernetes is an agent that collects and sends metrics about your Kubernetes cluster to your AppSignal account.
+AppSignal for Kubernetes collects and sends metrics about your Kubernetes cluster to your AppSignal account.
 
 ## Installation
 
@@ -14,7 +14,7 @@ Install AppSignal for Kubernetes by applying the deployment manifest:
 
     kubectl apply -f https://raw.githubusercontent.com/appsignal/appsignal-kubernetes/main/deployment.yaml
 
-This will create the `appsignal` namespace and deploy the AppSignal for Kubernetes agent in that namespace.
+This will create the `appsignal` namespace and deploy AppSignal for Kubernetes in that namespace.
 
 ### Using Helm
 

--- a/Rakefile
+++ b/Rakefile
@@ -139,7 +139,7 @@ task :generate_deployment do
   
   # Create a temporary values file with only the overrides needed for standalone deployment
   values_override = <<~VALUES
-    managed: false
+    kubectl: true
     image:
       tag: "#{current_version}"
   VALUES

--- a/charts/appsignal-kubernetes/templates/deployment.yaml
+++ b/charts/appsignal-kubernetes/templates/deployment.yaml
@@ -34,12 +34,14 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "appsignal-kubernetes.labels" -}}
+{{- if not .Values.kubectl }}
 helm.sh/chart: {{ include "appsignal-kubernetes.chart" . }}
-{{ include "appsignal-kubernetes.selectorLabels" . }}
+{{- end }}
+{{- include "appsignal-kubernetes.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-{{- if .Values.managed }}
+{{- if not .Values.kubectl }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 {{- end }}
@@ -62,7 +64,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
-
+{{- if .Values.kubectl }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+{{- end }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/appsignal-kubernetes/templates/namespace.yaml
+++ b/charts/appsignal-kubernetes/templates/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Release.Namespace }}
-  labels:
-    {{- include "appsignal-kubernetes.labels" . | nindent 4 }}

--- a/charts/appsignal-kubernetes/values.yaml
+++ b/charts/appsignal-kubernetes/values.yaml
@@ -31,8 +31,8 @@ appsignal:
 # Log level for the application
 logLevel: "info"
 
-# Whether resources should be described as managed by Helm
-managed: true
+# Whether this is a kubectl-oriented deployment (adds namespace, removes Helm labels)
+kubectl: false
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,14 +1,9 @@
 ---
-# Source: appsignal-kubernetes/templates/namespace.yaml
+# Source: appsignal-kubernetes/templates/deployment.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: appsignal
-  labels:
-    helm.sh/chart: appsignal-kubernetes-1.2.0
-    app.kubernetes.io/name: appsignal-kubernetes
-    app.kubernetes.io/instance: appsignal-kubernetes
-    app.kubernetes.io/version: "1.2.0"
 ---
 # Source: appsignal-kubernetes/templates/deployment.yaml
 apiVersion: v1
@@ -17,7 +12,6 @@ metadata:
   name: appsignal-kubernetes
   namespace: appsignal
   labels:
-    helm.sh/chart: appsignal-kubernetes-1.2.0
     app.kubernetes.io/name: appsignal-kubernetes
     app.kubernetes.io/instance: appsignal-kubernetes
     app.kubernetes.io/version: "1.2.0"
@@ -29,7 +23,6 @@ kind: ClusterRole
 metadata:
   name: appsignal-kubernetes
   labels:
-    helm.sh/chart: appsignal-kubernetes-1.2.0
     app.kubernetes.io/name: appsignal-kubernetes
     app.kubernetes.io/instance: appsignal-kubernetes
     app.kubernetes.io/version: "1.2.0"
@@ -46,7 +39,6 @@ kind: ClusterRoleBinding
 metadata:
   name: appsignal-kubernetes
   labels:
-    helm.sh/chart: appsignal-kubernetes-1.2.0
     app.kubernetes.io/name: appsignal-kubernetes
     app.kubernetes.io/instance: appsignal-kubernetes
     app.kubernetes.io/version: "1.2.0"
@@ -66,7 +58,6 @@ metadata:
   name: appsignal-kubernetes
   namespace: appsignal
   labels:
-    helm.sh/chart: appsignal-kubernetes-1.2.0
     app.kubernetes.io/name: appsignal-kubernetes
     app.kubernetes.io/instance: appsignal-kubernetes
     app.kubernetes.io/version: "1.2.0"


### PR DESCRIPTION
See [Intercom conversation](https://app.intercom.com/a/inbox/yzor8gyw/inbox/shared/all/conversation/215469890828287#part_id=comment-215469890828287-27076136097) for context.

The Helm chart included a `namespace.yaml` definition, which was useful so that the `deployment.yaml` generated from the Helm chart would contain a namespace. However, this breaks Helm's `--namespace` and `--create-namespace` flags, which are the preferred way to install a Helm chart on a specific namespace, and are what we recommend on our README.

Turn the existing `managed` flag into a `kubectl` flag that determines whether we're compiling the Helm template to be used via `kubectl`. This flag is off in the default values, but when it's on, it will cause the namespace to be present and remove Helm-related labels.